### PR TITLE
fix: update Cloak of Darkness to v0.9.92 API

### DIFF
--- a/stories/cloak-of-darkness/src/index.ts
+++ b/stories/cloak-of-darkness/src/index.ts
@@ -15,8 +15,8 @@ import type { GameEngine, CustomVocabulary } from '@sharpee/engine';
 import type { Parser } from '@sharpee/parser-en-us';
 // @ts-ignore - lang-en-us types not available yet
 import type { LanguageProvider } from '@sharpee/lang-en-us';
-import { 
-  WorldModel, 
+import {
+  WorldModel,
   IFEntity,
   IdentityTrait,
   ActorTrait,
@@ -27,11 +27,9 @@ import {
   SceneryTrait,
   ReadableTrait,
   IScopeRule,
-  LightSourceTrait,
   EntityType,
   Direction
 } from '@sharpee/world-model';
-import { ISemanticEvent } from '@sharpee/core';
 import type { IGameEvent, Effect, WorldQuery } from '@sharpee/event-processor';
 
 /**
@@ -665,64 +663,8 @@ export class CloakOfDarknessStory implements Story {
           requiresDirectObject: true,
           directObjectScope: 'VISIBLE'
         }
-      },
-      
-      // Override GO action to handle bar entry in darkness
-      {
-      id: 'GO_ENHANCED',
-      verbs: ['go', 'walk'],
-      priority: 100, // Higher priority than standard GO
-      
-      // Let standard GO do validation
-      validate: () => ({ valid: true }),
-      
-      execute: (command: any, context: any) => {
-        const events: any[] = [];
-        const direction = command.parsed?.direction || command.entities?.direction;
-        
-        // Get current location
-        const currentLoc = context.world.getLocation(context.actor.id);
-        const currentRoom = context.world.getEntity(currentLoc);
-        
-        if (currentRoom) {
-          const roomTrait = currentRoom.get(RoomTrait);
-          const exit = roomTrait?.exits?.[direction];
-          
-          // Check if we're entering the bar
-          if (exit?.destination === this.roomIds['bar']) {
-            // Move the player
-            context.world.moveEntity(context.actor.id, this.roomIds['bar']);
-            
-            // Emit the movement event - the bar's event handler will handle darkness
-            events.push(context.event('if.event.actor_moved', {
-              actorId: context.actor.id,
-              fromLocation: currentLoc,
-              toLocation: this.roomIds['bar'],
-              direction: direction
-            }));
-            
-            // Standard success message
-            events.push(context.event('action.success', {
-              actionId: 'GO',
-              messageId: 'moved',
-              params: {
-                direction: direction
-              }
-            }));
-            
-            return events;
-          }
-        }
-        
-        // Not going to bar, use standard GO action
-        const standardGo = context.stdlib.getAction('GO');
-        if (standardGo) {
-          return standardGo.execute(command, context);
-        }
-        
-        return events;
       }
-    }];
+    ];
   }
   
   /**


### PR DESCRIPTION
## Summary

The Cloak of Darkness demo game has three compounding API mismatches that prevent the core mechanic from working — the bar stays dark after hanging the cloak on the hook.

**Root causes fixed:**

- **"hang" verb never registered** — `extendParser()` with `parser.addVerb()` is dead code; the engine calls `getCustomVocabulary()` to register verbs. Added `getCustomVocabulary()` mapping "hang" → PUT_ON.
- **Entity `on` handlers never fire** — The event processor dispatches to `entities.target` (the direct object). For PUT_ON target=cloak, for GO target=direction — so the hook's and bar's `on` handlers never execute. Replaced with story-level `EventProcessor.registerHandler()` calls in `onEngineReady()`.
- **GO_ENHANCED has wrong `execute()` signature** — `execute(command, context)` but the Action interface is `execute(context: ActionContext)`. Standard GO already emits proper `ActorMovedEventData` with snapshots; no override needed.

## Changes

Single file: `stories/cloak-of-darkness/src/index.ts` (-348/+139 lines)

| Commit | What |
|--------|------|
| `fix: register "hang" verb via getCustomVocabulary API` | Replace dead `extendParser()` call, remove orphaned HANG action |
| `fix: use story-level EventProcessor handlers` | Add `onEngineReady()` with 3 handlers, remove dead entity `on` handlers |
| `fix: remove GO_ENHANCED and clean up imports` | Remove broken action, remove unused `LightSourceTrait`/`ISemanticEvent` |

## Test plan

- [ ] `hang cloak on hook` — verb recognized, cloak moves to hook, bar lights up
- [ ] `put cloak on hook` — also works (same PUT_ON action)
- [ ] Go south from foyer with cloak — dark bar, stumble message, disturbances increment
- [ ] After hanging cloak, go to bar — room is lit, message visible
- [ ] `read message` with 0 disturbances — victory
- [ ] `read message` after 3+ disturbances — loss
- [ ] Full walkthrough: foyer → west → hang cloak on hook → east → south → read message → win

🤖 Generated with [Claude Code](https://claude.com/claude-code)