### PR TITLE
test(npm): local-build npm consumer test for familyzoo

### DIFF
--- a/docs/context/session-20260617-2108-fix-tsbuildinfo-clean-scripts.md
+++ b/docs/context/session-20260617-2108-fix-tsbuildinfo-clean-scripts.md
@@ -131,4 +131,16 @@ No source code changed. No tests added.
 
 ---
 
-**Progressive update**: Session completed 2026-06-17 21:08 CST
+## Addendum — npm local-build consumer test (familyzoo)
+
+After PR #113 merged, added a pre-publish regression harness: `npm-test-familyzoo/`. It compiles and runs the familyzoo tutorial against the **locally built** npm packages in `~/.tsf-publish` (the `tsf build --npm` output), not the registry — the pre-publish sibling of the registry-based `npm-test-dungeo/`.
+
+- `gen-consumer.mjs` computes familyzoo's transitive `@sharpee/*` closure over the staged packages, `npm pack`s each into tarballs, and emits a consumer `package.json` with `file:` refs (third-party deps still resolve from the registry).
+- `run.sh` copies familyzoo `src/` + transcripts into a temp dir, `npm install`s the local tarballs, compiles with `tsc`, and runs all 16 transcripts. `--build` runs `tsf build --npm` first.
+- **Validated**: 15/16 transcripts pass against the local npm build. The one failure (`v16-scoring`) reproduces **identically in the workspace** build (walkthrough scores 75/100, transcript asserts "perfect score") — a pre-existing story-content issue, not a packaging defect. This confirms the local npm build is consumer-valid.
+
+**New open item (familyzoo content, low priority):** `v16-scoring` walkthrough reaches only 75/100 but asserts "perfect score" — either the walkthrough is incomplete or the assertion is aspirational.
+
+---
+
+**Progressive update**: Session completed 2026-06-17 21:08 CST; addendum 2026-06-17 22:40 CST (familyzoo npm local-build test)

--- a/npm-test-familyzoo/.gitignore
+++ b/npm-test-familyzoo/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+vendor/

--- a/npm-test-familyzoo/README.md
+++ b/npm-test-familyzoo/README.md
@@ -1,0 +1,45 @@
+# NPM Local-Build Test — Family Zoo
+
+Compiles and runs the **familyzoo** tutorial against the **locally built** npm
+packages in `~/.tsf-publish` — the output of `tsf build --npm` — rather than the
+npm registry. It proves the local build's publish artifacts work for an external
+consumer **before** anything is published.
+
+This is the pre-publish sibling of [`../npm-test-dungeo`](../npm-test-dungeo),
+which installs from the registry (i.e. tests already-published packages). This
+harness closes that gap: it tests what you just staged.
+
+## How it works
+
+1. `gen-consumer.mjs` walks familyzoo's `@sharpee/*` dependencies transitively
+   over the staged packages, `npm pack`s each into `vendor/*.tgz` (the exact
+   bytes `npm publish` would upload), and writes a consumer `package.json` whose
+   `@sharpee/*` deps are `file:` references to those tarballs. Third-party deps
+   (e.g. `fflate`) resolve from the registry, as a real consumer's install would.
+2. `run.sh` copies that into a throwaway temp dir along with familyzoo's `src/`
+   and transcripts, runs `npm install` (local tarballs only for `@sharpee/*`),
+   compiles with `tsc`, and runs every `tests/transcripts/*.transcript`.
+3. The temp dir is removed on exit.
+
+Nothing escapes to the npm registry for `@sharpee/*` packages, and nothing in
+the workspace is mutated.
+
+## Usage
+
+```bash
+# Use the existing ~/.tsf-publish staging (run `tsf build --npm` beforehand)
+./npm-test-familyzoo/run.sh
+
+# Build the local npm packages first, then test
+./npm-test-familyzoo/run.sh --build
+```
+
+Exit code is non-zero if compilation or any transcript fails.
+
+## Interpreting results
+
+Results should match the workspace build of familyzoo. A transcript that fails
+here **and** in the workspace is a story-content issue, not a packaging one
+(e.g. `v16-scoring` asserts a perfect score the walkthrough does not reach). A
+transcript that passes in the workspace but fails here points at a real
+packaging defect in the npm build (missing files, bad `exports`, wrong `main`).

--- a/npm-test-familyzoo/gen-consumer.mjs
+++ b/npm-test-familyzoo/gen-consumer.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * gen-consumer.mjs — pack the LOCAL @sharpee build for familyzoo and emit a
+ * consumer package.json that installs entirely from local tarballs.
+ *
+ * Owner context: npm-test-familyzoo harness (local-build npm regression).
+ * Public interface: CLI — node gen-consumer.mjs <stagingDir> <familyzooPkgJson> <vendorDir> <outPkgJson>
+ *   stagingDir       ~/.tsf-publish/sharpee (output of `tsf build --npm`)
+ *   familyzooPkgJson tutorials/familyzoo/package.json (source of direct deps)
+ *   vendorDir        where tarballs are written (temp/vendor)
+ *   outPkgJson       where the generated consumer package.json is written
+ *
+ * Walks familyzoo's @sharpee deps transitively over the staged packages,
+ * `npm pack`s each into vendorDir, and writes file: refs. Third-party deps
+ * (fflate, etc.) are left to resolve from the registry, as a real consumer's
+ * install would.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const [, , stagingDir, fzPkgPath, vendorDir, outPkgPath] = process.argv;
+if (!stagingDir || !fzPkgPath || !vendorDir || !outPkgPath) {
+  console.error('usage: gen-consumer.mjs <stagingDir> <familyzooPkgJson> <vendorDir> <outPkgJson>');
+  process.exit(2);
+}
+
+// Map @sharpee package name -> its staging subdirectory (don't assume dir == short name).
+const nameToDir = {};
+for (const d of readdirSync(stagingDir, { withFileTypes: true })) {
+  if (!d.isDirectory()) continue;
+  const pj = join(stagingDir, d.name, 'package.json');
+  if (!existsSync(pj)) continue;
+  const p = JSON.parse(readFileSync(pj, 'utf8'));
+  if (p.name?.startsWith('@sharpee/')) nameToDir[p.name] = d.name;
+}
+
+const sharpeeDepsOf = (name) => {
+  const dir = nameToDir[name];
+  if (!dir) return [];
+  const p = JSON.parse(readFileSync(join(stagingDir, dir, 'package.json'), 'utf8'));
+  return Object.keys(p.dependencies || {}).filter((n) => n.startsWith('@sharpee/') && nameToDir[n]);
+};
+
+// Seed from familyzoo's declared @sharpee deps; fail loudly if any are absent locally.
+const fz = JSON.parse(readFileSync(fzPkgPath, 'utf8'));
+const seed = Object.keys(fz.dependencies || {}).filter((n) => n.startsWith('@sharpee/'));
+const missing = seed.filter((n) => !nameToDir[n]);
+if (missing.length) {
+  console.error('ERROR: familyzoo deps absent from local staging: ' + missing.join(', '));
+  console.error('Run `tsf build --npm` from the repo root first.');
+  process.exit(1);
+}
+
+// Transitive closure over staged @sharpee deps.
+const closure = new Set();
+const stack = [...seed];
+while (stack.length) {
+  const n = stack.pop();
+  if (closure.has(n)) continue;
+  closure.add(n);
+  for (const d of sharpeeDepsOf(n)) if (!closure.has(d)) stack.push(d);
+}
+
+// transcript-tester supplies the `transcript-test` bin (dev-only).
+const TT = '@sharpee/transcript-tester';
+const haveTT = Boolean(nameToDir[TT]);
+
+const pack = (name) => {
+  const dir = join(stagingDir, nameToDir[name]);
+  const out = execSync(`npm pack "${dir}" --pack-destination "${vendorDir}" --ignore-scripts --json`, {
+    encoding: 'utf8',
+  });
+  return JSON.parse(out)[0].filename;
+};
+
+const dependencies = {};
+for (const n of [...closure].sort()) dependencies[n] = `file:vendor/${pack(n)}`;
+const devDependencies = { typescript: '^5.0.0' };
+if (haveTT) devDependencies[TT] = `file:vendor/${pack(TT)}`;
+
+writeFileSync(
+  outPkgPath,
+  JSON.stringify(
+    {
+      name: 'sharpee-npm-local-familyzoo',
+      version: '1.0.0',
+      private: true,
+      description: 'Local-build npm regression test: familyzoo compiled+run against ~/.tsf-publish output',
+      main: 'dist/index.js',
+      dependencies,
+      devDependencies,
+    },
+    null,
+    2,
+  ) + '\n',
+);
+
+console.log(`Packed ${closure.size} @sharpee packages${haveTT ? ' + transcript-tester' : ''}.`);
+console.log('Closure: ' + [...closure].map((n) => n.replace('@sharpee/', '')).sort().join(', '));

--- a/npm-test-familyzoo/run.sh
+++ b/npm-test-familyzoo/run.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------
+# Sharpee NPM Local-Build Test — Family Zoo
+#
+# Compiles and runs the familyzoo tutorial against the LOCALLY BUILT npm
+# packages in ~/.tsf-publish (the output of `tsf build --npm`) — NOT the
+# registry. Packs each needed @sharpee package into a tarball and installs
+# via file: refs, so nothing escapes to npm. Proves the local build's npm
+# output works for an external consumer BEFORE you publish.
+#
+# Sibling of npm-test-dungeo/ (which installs from the registry); this one
+# closes the pre-publish gap by testing what `tsf build --npm` just staged.
+#
+# Usage:
+#   ./npm-test-familyzoo/run.sh            # use existing ~/.tsf-publish staging
+#   ./npm-test-familyzoo/run.sh --build    # run `tsf build --npm` first, then test
+# -------------------------------------------------------------------
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FZ_DIR="$REPO_ROOT/tutorials/familyzoo"
+FZ_SRC="$FZ_DIR/src"
+FZ_TRANSCRIPTS="$FZ_DIR/tests/transcripts"
+STAGING="$HOME/.tsf-publish/sharpee"
+TMPDIR_BASE=""
+
+cleanup() {
+  if [[ -n "$TMPDIR_BASE" && -d "$TMPDIR_BASE" ]]; then
+    echo ""
+    echo "Cleaning up temp directory: $TMPDIR_BASE"
+    rm -rf "$TMPDIR_BASE"
+  fi
+}
+trap cleanup EXIT
+
+if [[ "${1:-}" == "--build" ]]; then
+  echo "--- Building local npm packages (tsf build --npm) ---"
+  ( cd "$REPO_ROOT" && tsf build --npm )
+  echo ""
+fi
+
+# Preconditions
+[[ -d "$FZ_SRC" ]] || { echo "ERROR: familyzoo source not found at $FZ_SRC"; exit 1; }
+if [[ ! -d "$STAGING" ]]; then
+  echo "ERROR: local npm staging not found at $STAGING"
+  echo "Run \`tsf build --npm\` from the repo root (or re-run with --build) first."
+  exit 1
+fi
+
+TMPDIR_BASE=$(mktemp -d)
+VENDOR="$TMPDIR_BASE/vendor"
+mkdir -p "$VENDOR"
+
+echo "=== Sharpee NPM Local-Build Test — Family Zoo ==="
+echo ""
+echo "Temp directory: $TMPDIR_BASE"
+echo "Local staging:  $STAGING"
+echo ""
+
+# 1. Pack the local @sharpee closure into tarballs + emit consumer package.json
+echo "--- Packing local @sharpee packages (transitive closure) ---"
+node "$SCRIPT_DIR/gen-consumer.mjs" "$STAGING" "$FZ_DIR/package.json" "$VENDOR" "$TMPDIR_BASE/package.json"
+echo ""
+
+# 2. Copy familyzoo source + transcripts + consumer tsconfig
+echo "--- Copying familyzoo source + transcripts ---"
+cp -r "$FZ_SRC" "$TMPDIR_BASE/src"
+rm -f "$TMPDIR_BASE/src/browser-entry.ts"
+mkdir -p "$TMPDIR_BASE/tests/transcripts"
+cp "$FZ_TRANSCRIPTS"/*.transcript "$TMPDIR_BASE/tests/transcripts/"
+cp "$SCRIPT_DIR/tsconfig.json" "$TMPDIR_BASE/tsconfig.json"
+echo "Copied: src/ ($(ls "$TMPDIR_BASE/src" | wc -l | tr -d ' ') files), $(ls "$TMPDIR_BASE/tests/transcripts" | wc -l | tr -d ' ') transcripts"
+echo ""
+
+# 3. Install (local tarballs only for @sharpee; registry for third-party) + compile
+cd "$TMPDIR_BASE"
+echo "--- npm install (local @sharpee tarballs) ---"
+npm install --no-fund --no-audit
+echo ""
+echo "--- Installed @sharpee versions ---"
+npm ls --depth=0 2>/dev/null | grep '@sharpee/' || true
+echo ""
+echo "--- Compiling familyzoo (tsc) ---"
+npx tsc
+echo "Compiled to dist/ ($(find dist -name '*.js' | wc -l | tr -d ' ') files)"
+echo ""
+
+# 4. Run all transcripts
+echo "--- Running familyzoo transcripts ---"
+echo ""
+PASS=0
+FAIL=0
+ERRORS=""
+for transcript in tests/transcripts/*.transcript; do
+  name=$(basename "$transcript" .transcript)
+  if npx transcript-test . "$transcript"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS="$ERRORS  FAIL: $name\n"
+  fi
+  echo ""
+done
+
+echo "==========================================="
+echo "  RESULTS: $PASS passed, $FAIL failed"
+echo "==========================================="
+if [[ $FAIL -gt 0 ]]; then
+  echo ""
+  echo "Failures:"
+  echo -e "$ERRORS"
+  exit 1
+fi
+echo ""
+echo "All familyzoo transcripts passed against the LOCAL npm build."
+exit 0

--- a/npm-test-familyzoo/tsconfig.json
+++ b/npm-test-familyzoo/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": false,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/browser-entry.ts"]
+}


### PR DESCRIPTION
## Summary

Adds `npm-test-familyzoo/` — a pre-publish regression harness that compiles and runs the **familyzoo** tutorial against the **locally built** npm packages in `~/.tsf-publish` (the `tsf build --npm` output) instead of the npm registry.

It's the pre-publish sibling of [`npm-test-dungeo/`](../tree/main/npm-test-dungeo) (which installs from the registry, i.e. tests already-published packages). This harness closes that gap: it validates *what you just built*, before publishing.

## How it works

- `gen-consumer.mjs` walks familyzoo's transitive `@sharpee/*` closure over the staged packages, `npm pack`s each into tarballs (the exact bytes `npm publish` would upload), and emits a consumer `package.json` with `file:` refs. Third-party deps (`fflate`, etc.) still resolve from the registry, as a real consumer's install would.
- `run.sh` copies familyzoo `src/` + transcripts into a throwaway temp dir, `npm install`s the local tarballs, compiles with `tsc`, and runs all 16 transcripts. `--build` rebuilds the npm staging first. The temp dir is cleaned up on exit; the workspace is never mutated.

## Validation

- **15/16 transcripts pass** against the local npm build.
- The lone failure (`v16-scoring`) reproduces **identically in the workspace** build — the walkthrough scores 75/100 but the transcript asserts "perfect score". Pre-existing story-content issue, not a packaging defect → confirms the local npm build is consumer-valid.

## Value

A transcript that passes in the workspace but fails here flags a real packaging defect (missing files, bad `exports`, wrong `main`) — the class of failure that only surfaces post-publish today.

## Follow-up (not in this PR)

familyzoo `v16-scoring`: walkthrough reaches only 75/100 but asserts "perfect score" — either the walkthrough is incomplete or the assertion is aspirational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)