### PR TITLE
docs(adr-180): build/test devkit + @sharpee/bootstrap (PROPOSED)

### DIFF
--- a/docs/architecture/adrs/adr-180-build-test-devkit.md
+++ b/docs/architecture/adrs/adr-180-build-test-devkit.md
@@ -30,16 +30,29 @@ exploration and per-decision rationale: `docs/work/sharpee-devkit/spec-20260617-
 
 ## Decision
 
-Build a **Sharpee-internal, self-tested devtool** (`@sharpee/devkit`) that owns
+Build a **published, Sharpee-specific, self-tested devtool** (`@sharpee/devkit`)
+shipped via the `@sharpee/sharpee` authoring SDK, that owns
 build/test/verify orchestration, and extract story loading into its own
 published package. tsf stays the compiler/publisher; **devkit orchestrates, tsf
 compiles**.
 
 Six decisions (resolved during the spec walkthrough):
 
-1. **`@sharpee/devkit` at `tools/devkit`**, CLI bin `devkit`. Tooling, not a
-   runtime library — kept out of the publishable `packages/` graph (no accidental
-   publish, no dep-graph contamination); mirrors `tools/zifmia`.
+1. **`@sharpee/devkit` at `packages/devkit`** (published), CLI bin `devkit`.
+   **Shipped as part of the npm install:** `@sharpee/sharpee` (the authoring SDK
+   umbrella) depends on `@sharpee/devkit`, so `npm install @sharpee/sharpee`
+   places the `devkit` bin in `node_modules/.bin` — a story author building their
+   game in any repo gets the tool without a separate install. This is required by
+   Decision 4 (a story is a location *anywhere*, including outside this
+   monorepo): an unpublished `tools/` tool could not reach external authors.
+   devkit is published and Sharpee-specific — *not* a generic standalone product.
+   It must live in `packages/` (not `tools/`) because the published
+   `packages/sharpee` depends on it. **Assumption:** `@sharpee/sharpee` is the
+   *authoring-time* SDK (authors install it to build/test; runtime ships built
+   bundles / the ADR-178 Story Runtime Baseline, not the umbrella), so devkit's
+   build-only transitive deps (tsf, bundler) do not bloat a story's runtime. If
+   that assumption breaks (stories runtime-depend on `@sharpee/sharpee`),
+   revisit — devkit would otherwise drag build tooling into runtime.
 2. **Full replacement of `build.sh`.** devkit fully owns the build; build.sh is
    **deleted at cutover** (no shim, no delegation). A **one-time parity check** —
    devkit outputs vs build.sh outputs — must pass before deletion, so no behavior
@@ -75,8 +88,9 @@ engine + world-model + parser + lang  (runtime libs, published)
 @sharpee/bootstrap   (published; entry-aware load + game assembly)
         ↑
    ┌────┼───────────────────────────┐
-transcript-tester   bundle(--play/--test)   @sharpee/devkit (tools/, internal)
+transcript-tester   bundle(--play/--test)   @sharpee/devkit (packages/, published)
                                                    ↑ orchestrates tsf (compile) + transcript-tester (run)
+                                                   ↑ shipped via @sharpee/sharpee (authoring SDK) → bin on npm install
 ```
 
 ### CLI surface (initial)
@@ -206,7 +220,7 @@ re-running `init` — losing it costs only the name shortcuts, never a build.
 
 ## Out of Scope
 
-- Publishing devkit (internal tool).
+- Making devkit a generic standalone product (it is published, but Sharpee-specific).
 - Rewriting tsf (devkit delegates compile/publish to it).
 - `shite`, `--runner`, the `.sharpee` bundle format (dropped/deferred).
 - Deleting `tools/shite/` / `dist/runner/` source (separate cleanup, to confirm).

--- a/docs/architecture/adrs/adr-180-build-test-devkit.md
+++ b/docs/architecture/adrs/adr-180-build-test-devkit.md
@@ -1,0 +1,232 @@
+# ADR-180: Build/Test devkit and `@sharpee/bootstrap`
+
+## Status: PROPOSED
+
+## Date: 2026-06-18
+
+## Context
+
+Sharpee's **build** layer is productized — `tsf` (`@davidcornelson/tsf`) is a
+real, owned, published compiler/publisher. The **bundle + story-build +
+transcript-run + npm-verify + publish-verify** layer never got the same
+treatment. It is accreted bash and copy-paste, with no single owner, no config,
+and no tests of its own. Concrete evidence (session 90c6c2/2026-06):
+
+- **Three hand-copied story loaders** — `transcript-tester/src/cli.ts`
+  (`loadStory`), `transcript-tester/src/fast-cli.ts` (`loadStoryAndCreateGame`),
+  and `scripts/bundle-entry.js` (inline copy). Guaranteed drift; the
+  unimplemented `entry:` transcript header is a direct symptom — a fix would have
+  to be written three times, and the bundle path silently ignored it.
+- **`build.sh` is a ~1,100-line untested bash monolith** (versioning, package
+  build, genai-api gen, bundling, story build, multiple client builds). The
+  silent `.tsbuildinfo` no-op bug lived here.
+- **Dead/stale scripts, no owner** — `publish:beta`, `npm-latest.sh`,
+  `pack-release.sh` (still references the deleted `text-service`).
+- **Three near-duplicate npm consumer harnesses** — `npm-test/`,
+  `npm-test-dungeo/`, `npm-test-familyzoo/`.
+
+Root cause: the test/bundle/verify layer is not a product. Full design
+exploration and per-decision rationale: `docs/work/sharpee-devkit/spec-20260617-build-test-devkit.md`.
+
+## Decision
+
+Build a **Sharpee-internal, self-tested devtool** (`@sharpee/devkit`) that owns
+build/test/verify orchestration, and extract story loading into its own
+published package. tsf stays the compiler/publisher; **devkit orchestrates, tsf
+compiles**.
+
+Six decisions (resolved during the spec walkthrough):
+
+1. **`@sharpee/devkit` at `tools/devkit`**, CLI bin `devkit`. Tooling, not a
+   runtime library — kept out of the publishable `packages/` graph (no accidental
+   publish, no dep-graph contamination); mirrors `tools/zifmia`.
+2. **Full replacement of `build.sh`.** devkit fully owns the build; build.sh is
+   **deleted at cutover** (no shim, no delegation). A **one-time parity check** —
+   devkit outputs vs build.sh outputs — must pass before deletion, so no behavior
+   is silently lost.
+3. **`@sharpee/bootstrap` at `packages/bootstrap`** (published) — the single
+   story loader. Resolves the story module **entry-aware** (`dist/<entry>.js` →
+   `dist/<entry>/index.js` → `dist/index.js`) and assembles GameEngine + world +
+   player + parser + language + perception into a runnable game. Depends only
+   downward on runtime libs; transcript-tester, the bundle, and devkit all depend
+   on it (no cycle). This closes the long-standing `entry:` gap.
+4. **A story is a location; no committed config; no directory convention.**
+   devkit targets a path (`devkit test <path>`). `devkit init <location>`
+   optionally registers a name→path mapping in a **user-level memory at
+   `~/.sharpee/devkit`** (machine-level, not committed; stories may live
+   anywhere, including other repos). The memory is pure convenience over the
+   location — never a source of truth; nothing requires `init`.
+5. **Targets: CLI bundle, `browser`, `zifmia`.** `shite` (abandoned parts bin)
+   and `--runner` (dormant legacy interpreter) are **dropped** — devkit does not
+   build them; their entry points die with build.sh. The `.sharpee` story-bundle
+   format is **deferred** (reconstructable later). Dropping from the build ≠
+   deleting `tools/shite/` / `dist/runner/` source (separate cleanup).
+6. **Keep the platform bundle (`dist/cli/sharpee.js`)** as devkit's **internal
+   fast engine** (~170ms load). `devkit` is the single user-facing front door
+   (`devkit test/play <loc>`); raw `node dist/cli/sharpee.js` survives as a
+   low-level entry devkit invokes. `bundle-entry.js`'s inline loader is replaced
+   by `@sharpee/bootstrap`.
+
+### Layering
+
+```
+engine + world-model + parser + lang  (runtime libs, published)
+        ↑
+@sharpee/bootstrap   (published; entry-aware load + game assembly)
+        ↑
+   ┌────┼───────────────────────────┐
+transcript-tester   bundle(--play/--test)   @sharpee/devkit (tools/, internal)
+                                                   ↑ orchestrates tsf (compile) + transcript-tester (run)
+```
+
+### CLI surface (initial)
+
+`devkit build|bundle|test|test:npm|verify|clean|init|list` — plus `play` and
+`watch` as needed. `test`/`play` take a location or a registered name.
+
+### `@sharpee/bootstrap` public API (contract)
+
+Three consumers depend on this surface, so it is fixed here:
+
+```ts
+// Resolve the story module file to require, entry-aware. Throws on traversal
+// (entry containing '/', '\\', '..', or absolute) and on no candidate found.
+function resolveStoryModulePath(location: string, entry?: string): string;
+
+// Load + assemble a runnable game. Resolves the module, requires it, takes
+// `story || default`, builds GameEngine + world + player + parser + language +
+// perception, applies story.extendParser/extendLanguage, setStory, start.
+function loadStory(location: string, opts?: { entry?: string }): Promise<LoadedGame>;
+
+interface LoadedGame {
+  engine: GameEngine;
+  world: WorldModel;
+  player: IFEntity;
+  parser: Parser;
+  language: LanguageProvider;
+  execute(input: string): Promise<TurnResult>;   // run one command
+  getOutput(): string;                            // captured text since last read
+  // (superset of today's transcript-tester TestableGame; that type is replaced by this)
+}
+```
+
+`resolveStoryModulePath` is the single home for entry resolution; no front-end
+reimplements it.
+
+### `~/.sharpee/devkit` memory format
+
+A JSON file: `{ "stories": { "<name>": { "path": "<absolute path>" } } }`.
+`devkit init <location> [--name X]` upserts an entry (default name = basename).
+On lookup by name, devkit resolves the path and **errors if it no longer
+exists** (stale registration is reported, never silently skipped); `devkit list`
+flags stale entries. The file is machine-level, git-ignored, and rebuildable by
+re-running `init` — losing it costs only the name shortcuts, never a build.
+
+## Migration (phased; each independently shippable)
+
+- **Phase 1 — `@sharpee/bootstrap`.** Create the package and implement
+  entry-aware resolution + game assembly per the API contract above.
+  **Atomic-completion contract:** Phase 1 is not done until **all three**
+  former loaders — `transcript-tester/src/cli.ts`, `transcript-tester/src/fast-cli.ts`,
+  **and** `scripts/bundle-entry.js` — route through bootstrap and contain no
+  story-loading logic of their own. Updating only two leaves the bundle path
+  silently broken (the failure mode that hid the unimplemented `entry:` header).
+  Concrete edit set:
+  - `packages/bootstrap/*` — new package (see registration below).
+  - `transcript-tester`: `types.ts` (add `entry?: string` to `TranscriptHeader`),
+    `parser.ts` (already captures `entry`; add validation warning), `cli.ts` +
+    `fast-cli.ts` (delegate to bootstrap, thread `header.entry` at the
+    per-transcript reload), `index.ts` (drop the local loader exports / re-export
+    bootstrap as needed).
+  - `scripts/bundle-entry.js` — replace the inline `loadStoryAndCreateGame` with
+    bootstrap.
+  - **bootstrap registration (Phase-1 task, not optional)** — the 6 points:
+    `ts-forge.config.json`, `packages/sharpee/package.json`,
+    `packages/sharpee/src/index.ts`, `packages/sharpee/tsconfig.json`, `build.sh`,
+    root `package.json` (per the new-package checklist).
+  Supersedes the standalone `entry:` plan
+  (`docs/work/transcript-entry-support/plan-20260617-entry-header-support.md`),
+  which holds the detailed resolution/threading design.
+  *Delivers the `entry:` fix and eliminates the three-loader duplication.*
+- **Phase 2 — `devkit test:npm`.** One parameterized npm consumer-test over any
+  location; retire `npm-test/`, `npm-test-dungeo/`, `npm-test-familyzoo/`.
+- **Phase 3 — `devkit build/bundle` + full build.sh replacement.** devkit
+  orchestrates tsf for compile, produces the bundle and the three live targets,
+  the location/`init`/`~/.sharpee/devkit` model, the parity gate; delete build.sh
+  and the dead scripts after parity passes, and update CLAUDE.md + docs (AC-8) in
+  the same cutover.
+
+## Invariants
+
+- A story is referable by raw location with zero machine state; `~/.sharpee/devkit`
+  is convenience only.
+- Exactly one story-loading implementation (`@sharpee/bootstrap`); no front-end
+  hand-copies it.
+- devkit depends on tsf and transcript-tester; never the reverse (no cycle).
+- devkit asserts its build outputs exist (no silent `✓` on an empty/no-op build —
+  the `.tsbuildinfo` failure class is precluded by design).
+- build.sh is not deleted until the parity check passes.
+
+## Acceptance Criteria
+
+- **AC-1:** `@sharpee/bootstrap` is a published package; `cli.ts`, `fast-cli.ts`,
+  and `bundle-entry.js` contain no story-loading logic of their own.
+- **AC-2:** A transcript with `entry: v16` loads `dist/v16.js`; familyzoo
+  `v16-scoring` passes via both `transcript-test` and the bundle path; `v01`–`v15`
+  and dungeo unchanged.
+- **AC-3:** `devkit test <location>` and `devkit test <name>` (after `init`) both
+  run a story with no committed config.
+- **AC-4:** `devkit test:npm <location>` reproduces the three retired harnesses'
+  behavior over any story.
+- **AC-5:** `devkit build` produces byte-identical artifacts to build.sh for the
+  three live targets (parity gate) before build.sh is removed.
+- **AC-6:** A no-op/empty build fails loudly (artifact assertion), not silently.
+- **AC-7:** devkit ships its own test suite + a validation harness (real build +
+  real transcript run + real npm consumer test against a fixture story).
+- **AC-8:** at build.sh cutover, every reference to build.sh and the dropped
+  flags (`-c shite`, `--runner`) in `CLAUDE.md`, package CLAUDE.md files, and
+  `docs/` is updated to the `devkit` equivalents — no doc describes a deleted
+  command.
+
+## Tests required for AC closure
+
+- bootstrap unit: entry resolution (file form, dir form, default, traversal
+  rejection, nonexistent → throws).
+- bootstrap integration: load + run a fixture story end-to-end.
+- devkit integration (real-path): build → bundle → transcript run → npm consumer
+  test against a fixture, all on production code paths (no stubs).
+- parity harness: diff devkit vs build.sh outputs for the three targets.
+
+## Constrains Future Sessions
+
+- New build/test/run capabilities go in devkit, not new bash scripts.
+- Story loading changes go in `@sharpee/bootstrap` only.
+- Transcripts may pin a story sub-entry via `entry:`, resolved by bootstrap.
+- No new committed story registry; locations + `~/.sharpee/devkit` are the model.
+
+## Out of Scope
+
+- Publishing devkit (internal tool).
+- Rewriting tsf (devkit delegates compile/publish to it).
+- `shite`, `--runner`, the `.sharpee` bundle format (dropped/deferred).
+- Deleting `tools/shite/` / `dist/runner/` source (separate cleanup, to confirm).
+- CI gates (per project direction, recurrence prevention stays local).
+
+## Open Questions (resolve during implementation; non-blocking to acceptance)
+
+1. **tsf ↔ arbitrary locations.** tsf's project list lives in
+   `ts-forge.config.json`; a story can now be any location. Does devkit invoke
+   tsf against the story's own `tsconfig` ad hoc, or run the story's own build
+   script (familyzoo's is `tsc`)? Reconcile with the existing tsf project list.
+2. **Parity-gate capture.** How build.sh's current outputs are captured/frozen to
+   diff devkit against before deletion.
+
+(bootstrap's 6-point registration was previously listed here; it is now a
+Phase-1 task in the Migration section, not an open question.)
+
+## Prior Art
+
+- `tsf` / DevArch — productized tools with single entry, declarative config, own
+  validation harness, versioned lifecycle. devkit follows that shape.
+- `git init` / `npm init` — explicit registration of a location into tool state,
+  vs directory-scanning convention.

--- a/docs/architecture/adrs/adr-180-build-test-devkit.md
+++ b/docs/architecture/adrs/adr-180-build-test-devkit.md
@@ -69,11 +69,18 @@ Six decisions (resolved during the spec walkthrough):
    `~/.sharpee/devkit`** (machine-level, not committed; stories may live
    anywhere, including other repos). The memory is pure convenience over the
    location — never a source of truth; nothing requires `init`.
-5. **Targets: CLI bundle, `browser`, `zifmia`.** `shite` (abandoned parts bin)
-   and `--runner` (dormant legacy interpreter) are **dropped** — devkit does not
-   build them; their entry points die with build.sh. The `.sharpee` story-bundle
-   format is **deferred** (reconstructable later). Dropping from the build ≠
-   deleting `tools/shite/` / `dist/runner/` source (separate cleanup).
+5. **Targets: CLI bundle, `browser`, `zifmia`.** The **`browser`** target is the
+   author's player-facing deliverable: `devkit build <story> --browser` produces
+   a **fully self-contained, encapsulated web app** at `dist/web/{story}/` — the
+   framework-free platform-browser runtime (ADR-170) and the compiled story
+   bundled into a single optimized payload that **boots without fetching the
+   platform piecemeal**, so players get a fast page load. An author can build a
+   complete, fast, self-contained browser version of their story and ship it
+   anywhere static files are served. `shite` (abandoned parts bin) and `--runner`
+   (dormant legacy interpreter) are **dropped** — devkit does not build them;
+   their entry points die with build.sh. The `.sharpee` story-bundle format is
+   **deferred** (reconstructable later). Dropping from the build ≠ deleting
+   `tools/shite/` / `dist/runner/` source (separate cleanup).
 6. **Keep the platform bundle (`dist/cli/sharpee.js`)** as devkit's **internal
    fast engine** (~170ms load). `devkit` is the single user-facing front door
    (`devkit test/play <loc>`); raw `node dist/cli/sharpee.js` survives as a
@@ -201,6 +208,12 @@ re-running `init` — losing it costs only the name shortcuts, never a build.
   flags (`-c shite`, `--runner`) in `CLAUDE.md`, package CLAUDE.md files, and
   `docs/` is updated to the `devkit` equivalents — no doc describes a deleted
   command.
+- **AC-9:** `devkit build <story> --browser` emits a self-contained
+  `dist/web/{story}/` bundle (platform + story in one optimized payload). Served
+  as static files with no app server and an empty network cache, it boots and
+  reaches the story's first turn with a **single fast load** — no piecemeal
+  platform module fetches. The directory is portable (copy it anywhere static
+  files are served and it runs).
 
 ## Tests required for AC closure
 

--- a/docs/context/session-20260617-2108-fix-tsbuildinfo-clean-scripts.md
+++ b/docs/context/session-20260617-2108-fix-tsbuildinfo-clean-scripts.md
@@ -144,3 +144,31 @@ After PR #113 merged, added a pre-publish regression harness: `npm-test-familyzo
 ---
 
 **Progressive update**: Session completed 2026-06-17 21:08 CST; addendum 2026-06-17 22:40 CST (familyzoo npm local-build test)
+
+---
+
+## Addendum 2 — build/test productization (devkit + bootstrap), 2026-06-18
+
+The familyzoo `v16-scoring` research traced to an unimplemented `entry:`
+transcript header, which exposed three hand-copied story loaders and a broader
+truth: the build half is productized (tsf) but the test/bundle/verify half is
+accreted bash + copy-paste. Stepped back from patching to design a productized,
+self-tested build/test devtool (the "hard app like DevArch" framing).
+
+Outcome — a converged spec and **ADR-180 (PROPOSED, READY after adr-review)**:
+- `@sharpee/devkit` (`tools/devkit`, internal) orchestrates; **tsf compiles**.
+- `@sharpee/bootstrap` (`packages/bootstrap`, published) — the single
+  entry-aware story loader; kills the 3-loader duplication and ships the `entry:`
+  fix. transcript-tester, the bundle, and devkit all depend on it (no cycle).
+- A story is a **location** (no committed config, no directory convention);
+  `devkit init` registers name→path in user-level `~/.sharpee/devkit` memory.
+- **Full replacement** of build.sh (parity-gated). Targets: CLI bundle +
+  browser + zifmia; **dropped** shite + `--runner`; deferred `.sharpee`.
+- Bundle kept as devkit's internal fast engine; `devkit` is the front door.
+
+Artifacts: `docs/work/sharpee-devkit/spec-20260617-build-test-devkit.md`,
+`docs/architecture/adrs/adr-180-build-test-devkit.md`,
+`docs/work/transcript-entry-support/plan-20260617-entry-header-support.md`
+(entry: design, superseded by/folded into ADR-180 Phase 1). Ran adr-review →
+NEEDS WORK → folded six contract/AC tightenings → READY. **Not yet accepted; no
+implementation started.** Next: accept ADR-180, then Phase 1 (`@sharpee/bootstrap`).

--- a/docs/context/session-20260617-2108-fix-tsbuildinfo-clean-scripts.md
+++ b/docs/context/session-20260617-2108-fix-tsbuildinfo-clean-scripts.md
@@ -156,7 +156,9 @@ accreted bash + copy-paste. Stepped back from patching to design a productized,
 self-tested build/test devtool (the "hard app like DevArch" framing).
 
 Outcome — a converged spec and **ADR-180 (PROPOSED, READY after adr-review)**:
-- `@sharpee/devkit` (`tools/devkit`, internal) orchestrates; **tsf compiles**.
+- `@sharpee/devkit` (`packages/devkit`, **published**, shipped via the
+  `@sharpee/sharpee` authoring SDK so authors get the CLI on `npm install`)
+  orchestrates; **tsf compiles**.
 - `@sharpee/bootstrap` (`packages/bootstrap`, published) — the single
   entry-aware story loader; kills the 3-loader duplication and ships the `entry:`
   fix. transcript-tester, the bundle, and devkit all depend on it (no cycle).

--- a/docs/work/sharpee-devkit/spec-20260617-build-test-devkit.md
+++ b/docs/work/sharpee-devkit/spec-20260617-build-test-devkit.md
@@ -3,8 +3,10 @@
 **Date**: 2026-06-17
 **Status**: DRAFT SPEC — convergence doc, pre-ADR. Decisions in §7 must be
 resolved before this becomes an ADR and any code is written.
-**Scope decision (set)**: a **Sharpee-internal, tested devtool package** — not a
-published product. Owns build/test/verify orchestration.
+**Scope decision (set, corrected 2026-06-18)**: a **published, Sharpee-specific,
+tested devtool** — shipped via the `@sharpee/sharpee` authoring SDK so authors
+get the `devkit` CLI on `npm install`. Sharpee-specific, not a generic standalone
+product. Owns build/test/verify orchestration.
 **Origin**: session 90c6c2. A string of build/test fixes (tsbuildinfo no-op,
 clean drift, dead `publish:beta`/`npm-latest.sh`, the unimplemented `entry:`
 header) revealed the tooling is accreted bash + copy-paste, not a product.
@@ -38,7 +40,7 @@ and tests everything.
 
 ## 2. Goal
 
-A single Sharpee-internal devtool package (**working name `@sharpee/devkit`**)
+A single published, Sharpee-specific devtool package (**`@sharpee/devkit`**)
 that owns build/test/verify orchestration with **one** story loader, is
 config-driven, and is **tested in its own right** — the same "hard app" shape as
 DevArch (single entry, declarative config, own validation harness, versioned).
@@ -81,7 +83,7 @@ copy.
 
 ## 5. Architecture sketch
 
-- Package at `packages/devkit` (or `tools/devkit` — §7).
+- Package at `packages/devkit` (published; shipped via `@sharpee/sharpee`).
 - A single `StoryLoader` module, entry-aware (resolves `dist/<entry>.js` →
   `dist/<entry>/index.js` → default `dist/index.js`). cli.ts, fast-cli.ts, and
   `bundle-entry.js` all import it — no hand-copies.
@@ -106,11 +108,16 @@ copy.
 
 ## 7. Decisions needed (resolve before ADR)
 
-1. **Package location/name** — RESOLVED (2026-06-17): `tools/devkit`, package
-   `@sharpee/devkit`, CLI bin `devkit`. Rationale: it's tooling not a runtime
-   library; `tools/` keeps it out of the publishable graph (no accidental npm
-   publish, no dep-graph contamination) and mirrors `tools/zifmia`; still a
-   normal pnpm workspace member.
+1. **Package location/name** — RESOLVED (2026-06-17; **corrected 2026-06-18**):
+   `packages/devkit`, package `@sharpee/devkit`, CLI bin `devkit`, **published**.
+   Shipped as part of the npm install — `@sharpee/sharpee` (authoring SDK) depends
+   on it, so `npm install @sharpee/sharpee` places the `devkit` bin in
+   `node_modules/.bin`. Must be `packages/` (not the earlier `tools/devkit`)
+   because published `packages/sharpee` depends on it, and because Decision 4
+   (story = location anywhere) requires external authors to get devkit via npm.
+   Assumption: `@sharpee/sharpee` is the authoring-time SDK, so devkit's
+   build-only deps don't bloat a story's runtime. (Superseded the initial
+   "internal `tools/devkit`, not published" call after the cross-wire was caught.)
 2. **build.sh disposition** — RESOLVED (2026-06-17): **full replacement.** devkit
    fully owns the build pipeline; build.sh is deleted at cutover (no shim, no
    delegation to it). Safeguard: a one-time parity check (devkit outputs vs
@@ -163,7 +170,7 @@ copy.
 
 ## 8. Non-goals
 
-- Not a published/standalone product (scope decision: internal).
+- Not a generic standalone product (it is published, but Sharpee-specific).
 - Not a rewrite of tsf — devkit orchestrates, tsf compiles.
 - Not changing story/game logic or runtime package boundaries.
 

--- a/docs/work/sharpee-devkit/spec-20260617-build-test-devkit.md
+++ b/docs/work/sharpee-devkit/spec-20260617-build-test-devkit.md
@@ -149,8 +149,12 @@ copy.
    against tsf's project list); mirrors `~/.devarch` tooling pattern. Nothing is
    bolted onto `ts-forge.config.json`.
 5. **Client builds / targets** — RESOLVED (2026-06-17): devkit covers only the
-   **three live targets** — CLI platform bundle, `browser` (single-player static
-   client), `zifmia` (ADR-177 multi-user server). **Dropped:** `shite` (abandoned
+   **three live targets** — CLI platform bundle, `browser`, `zifmia` (ADR-177
+   multi-user server). The **`browser`** target is the author's player-facing
+   deliverable: a **fully self-contained, encapsulated** web app
+   (`dist/web/{story}/`) bundling the framework-free platform-browser runtime +
+   the compiled story into one optimized payload that boots without piecemeal
+   platform fetches — fast page load for players, portable to any static host. **Dropped:** `shite` (abandoned
    parts bin) and `--runner` (dormant legacy interpreter) — devkit will not build
    them; their build entry points die with build.sh. **Deferred:** the `.sharpee`
    story-bundle format — reconstructable later, out of initial scope. (Dropping

--- a/docs/work/sharpee-devkit/spec-20260617-build-test-devkit.md
+++ b/docs/work/sharpee-devkit/spec-20260617-build-test-devkit.md
@@ -1,0 +1,175 @@
+# Spec — Sharpee build/test devkit (productization)
+
+**Date**: 2026-06-17
+**Status**: DRAFT SPEC — convergence doc, pre-ADR. Decisions in §7 must be
+resolved before this becomes an ADR and any code is written.
+**Scope decision (set)**: a **Sharpee-internal, tested devtool package** — not a
+published product. Owns build/test/verify orchestration.
+**Origin**: session 90c6c2. A string of build/test fixes (tsbuildinfo no-op,
+clean drift, dead `publish:beta`/`npm-latest.sh`, the unimplemented `entry:`
+header) revealed the tooling is accreted bash + copy-paste, not a product.
+
+---
+
+## 1. Problem
+
+The **build** half is productized — `tsf` (`@davidcornelson/tsf`) is a real,
+owned, published compiler/publisher. The **bundle + story-build + transcript-run
++ npm-verify + publish-verify** half never was. Concrete smells:
+
+- **Three hand-copied story loaders** — `transcript-tester/src/cli.ts`
+  (`loadStory`), `transcript-tester/src/fast-cli.ts` (`loadStoryAndCreateGame`),
+  and `scripts/bundle-entry.js` (inline copy). Guaranteed drift; the
+  unimplemented `entry:` header is a direct symptom (a fix must be written three
+  times).
+- **`build.sh` is a ~1,100-line untested bash monolith** doing versioning,
+  package build, genai-api gen, bundling, story build, and 4+ client builds. The
+  silent `.tsbuildinfo` no-op lived here.
+- **Dead/stale scripts, no owner** — `publish:beta` (just fixed),
+  `npm-latest.sh` (just deleted), `pack-release.sh` (references the deleted
+  `text-service`, hardcodes `0.9.60-beta`).
+- **Three near-duplicate npm consumer harnesses** — `npm-test/`,
+  `npm-test-dungeo/`, `npm-test-familyzoo/`, same shape copied.
+- **Unenforced conventions** — `entry:` headers authored into transcripts that no
+  runner reads.
+
+Root cause: no single owner, no config, no self-tests for the layer that builds
+and tests everything.
+
+## 2. Goal
+
+A single Sharpee-internal devtool package (**working name `@sharpee/devkit`**)
+that owns build/test/verify orchestration with **one** story loader, is
+config-driven, and is **tested in its own right** — the same "hard app" shape as
+DevArch (single entry, declarative config, own validation harness, versioned).
+
+## 3. Boundaries
+
+**devkit OWNS (orchestration + test):**
+- One entry-aware `StoryLoader`/runner — the single source all front-ends call.
+- Transcript test execution.
+- npm consumer-test, parameterized over any story (collapses the three
+  `npm-test-*` dirs).
+- Bundle assembly (`dist/cli/sharpee.js`).
+- Build orchestration across packages + stories.
+- Publish verification (dry-run of the npm output).
+
+**devkit DELEGATES to `tsf` (compiler/publisher — keep as-is):**
+- TypeScript compilation (local/esm/npm targets).
+- npm publish.
+- devkit calls tsf; it does **not** re-implement compilation.
+
+**Out of devkit (for now):** story game logic, the runtime packages themselves.
+
+**tsf vs devkit, one line:** tsf compiles and publishes; devkit orchestrates,
+bundles, and tests. Clean split — no overlap.
+
+## 4. Proposed CLI surface
+
+```
+devkit build      [--story X] [--skip pkg]     # orchestrate package+story build (delegates compile to tsf)
+devkit bundle     [--story X]                  # assemble dist/cli/sharpee.js
+devkit test       <transcripts...> [--chain]   # run transcripts (the ONE runner, entry-aware)
+devkit test:npm   --story X [--local|--registry]  # npm consumer test, any story
+devkit verify                                   # tsf build --npm + publish dry-run
+devkit clean                                    # build-artifact hygiene (tsbuildinfo, dist, dist-esm)
+```
+
+The existing `node dist/cli/sharpee.js --test/--play` stays as the fast runtime
+entry, but its transcript path calls devkit's shared loader instead of an inline
+copy.
+
+## 5. Architecture sketch
+
+- Package at `packages/devkit` (or `tools/devkit` — §7).
+- A single `StoryLoader` module, entry-aware (resolves `dist/<entry>.js` →
+  `dist/<entry>/index.js` → default `dist/index.js`). cli.ts, fast-cli.ts, and
+  `bundle-entry.js` all import it — no hand-copies.
+- Config-driven (`sharpee.devkit.json` or reuse/extend an existing config — §7).
+- Programmatic API + thin CLI.
+- Self-tested: unit tests (loader resolution, config) + integration tests (real
+  build, real transcript run, real npm consumer test), plus a validation harness
+  mirroring DevArch's `run.sh`.
+
+## 6. Phased migration (each phase independently shippable)
+
+- **Phase 0** — this spec → ADR once §7 is resolved.
+- **Phase 1** — extract the single entry-aware `StoryLoader`; point all three
+  front-ends at it. *Delivers the `entry:` fix correctly and kills the 3-copy
+  bug.* Smallest, highest-leverage step; foundation for the rest.
+- **Phase 2** — generalize the npm consumer-test into one parameterized command;
+  retire `npm-test/`, `npm-test-dungeo/`, `npm-test-familyzoo/`.
+- **Phase 3** — move `build.sh` orchestration into `devkit build`/`bundle`
+  (delegating compile to tsf); retire dead scripts (`pack-release.sh`, etc.).
+- **Phase 4** — client build targets (browser/runner/zifmia) as devkit targets,
+  if in scope (§7).
+
+## 7. Decisions needed (resolve before ADR)
+
+1. **Package location/name** — RESOLVED (2026-06-17): `tools/devkit`, package
+   `@sharpee/devkit`, CLI bin `devkit`. Rationale: it's tooling not a runtime
+   library; `tools/` keeps it out of the publishable graph (no accidental npm
+   publish, no dep-graph contamination) and mirrors `tools/zifmia`; still a
+   normal pnpm workspace member.
+2. **build.sh disposition** — RESOLVED (2026-06-17): **full replacement.** devkit
+   fully owns the build pipeline; build.sh is deleted at cutover (no shim, no
+   delegation to it). Safeguard: a one-time parity check (devkit outputs vs
+   build.sh outputs) must pass before build.sh is deleted, so no behavior is
+   silently lost. Implication: devkit must reach parity on everything build.sh
+   does — package build (via tsf), genai-api gen, bundling, version stamping, and
+   client builds — which pre-constrains Decision 5 toward "devkit owns client
+   builds."
+3. **Shared loader home** — RESOLVED (2026-06-17): the loader is **its own
+   published package `@sharpee/bootstrap`** (`packages/bootstrap`), not folded
+   into transcript-tester or devkit. It resolves the story module (entry-aware:
+   `dist/<entry>.js` → `dist/<entry>/index.js` → `dist/index.js`) and assembles
+   GameEngine + world + player + parser + language + perception into a runnable
+   game. Layering: bootstrap depends only downward on runtime libs; transcript-
+   tester, the bundle (`--play`/`--test`), and devkit all depend on bootstrap (no
+   cycle). Consequence: a new published `@sharpee/*` package — needs the 6-point
+   new-package registration and joins the publish set. The `entry:` fix lands as
+   part of building bootstrap and routing all three former loaders through it.
+4. **Config / story registry** — RESOLVED (2026-06-18): **a story is just a
+   location; no committed config, no directory convention.** devkit targets a
+   path directly (`devkit build <path>`, `devkit test <path> …`) — the canonical,
+   reproducible input requiring no machine state. `devkit init <location>`
+   optionally registers a name→path mapping into a **user-level memory at
+   `~/.sharpee/devkit`** (machine-level, not committed; can point at stories
+   anywhere, incl. other repos) so a story can later be referenced by name;
+   `devkit list` shows registered stories. The memory is pure convenience over
+   the location — never a source of truth, nothing requires `init`. Consequences:
+   no committed `devkit.config.json` (so no second repo-level registry to drift
+   against tsf's project list); mirrors `~/.devarch` tooling pattern. Nothing is
+   bolted onto `ts-forge.config.json`.
+5. **Client builds / targets** — RESOLVED (2026-06-17): devkit covers only the
+   **three live targets** — CLI platform bundle, `browser` (single-player static
+   client), `zifmia` (ADR-177 multi-user server). **Dropped:** `shite` (abandoned
+   parts bin) and `--runner` (dormant legacy interpreter) — devkit will not build
+   them; their build entry points die with build.sh. **Deferred:** the `.sharpee`
+   story-bundle format — reconstructable later, out of initial scope. (Dropping
+   from devkit's build ≠ deleting `tools/shite/` / `dist/runner/` source; that's a
+   separate cleanup to confirm.) For `browser`/`zifmia`, devkit likely
+   orchestrates their existing builds (zifmia has its own Dockerfile +
+   `mac-release.sh`) rather than owning the logic — see Decision 6 / future detail.
+   This shrinks the Decision-2 parity surface to these three targets.
+6. **The bundle** — RESOLVED (2026-06-18): **keep** `dist/cli/sharpee.js` (the
+   ~170ms platform bundle earns its place), but as devkit's **internal fast
+   engine**, not the user-facing entry. `devkit` is the single front door
+   (`devkit test <loc>`, `devkit play <loc>`); devkit produces the bundle and
+   runs against it for speed. `bundle-entry.js`'s hand-copied loader is replaced
+   by `@sharpee/bootstrap`. Raw `node dist/cli/sharpee.js` survives as a low-level
+   entry devkit invokes / power-user escape hatch, but is no longer the blessed
+   path.
+
+## 8. Non-goals
+
+- Not a published/standalone product (scope decision: internal).
+- Not a rewrite of tsf — devkit orchestrates, tsf compiles.
+- Not changing story/game logic or runtime package boundaries.
+
+## 9. Validation approach (DevArch parallel)
+
+devkit ships with its own test suite and a validation harness that runs a real
+build + a real transcript run + a real npm consumer test against a fixture
+story — so the tool that tests Sharpee is itself tested. No bash path goes
+untested the way `build.sh` is today.

--- a/docs/work/transcript-entry-support/plan-20260617-entry-header-support.md
+++ b/docs/work/transcript-entry-support/plan-20260617-entry-header-support.md
@@ -1,0 +1,157 @@
+# Plan — Honor the `entry:` transcript header in transcript-tester
+
+**Date**: 2026-06-17
+**Topic**: transcript-tester per-transcript story-entry selection
+**Origin**: Research into familyzoo `v16-scoring` failure (session 90c6c2). The
+transcript declares `entry: v16` but no runner consumes it, so it (and every
+versioned familyzoo transcript) runs against the default export `index.js` →
+`v17`. v16-scoring asserts a perfect score at 75 points; v17 raised the max to
+100, so the assertion fails. The walkthrough is correct *for v16* — it is never
+run against v16.
+
+**Status**: PROPOSED — platform change (`@sharpee/transcript-tester`). Not yet
+approved for implementation.
+
+---
+
+## Goal
+
+Make both transcript runners honor an optional `entry:` header in a transcript:
+when present, load the story from `dist/<entry>.js` or `dist/<entry>/index.js`
+instead of the default `dist/index.js`. When absent, behavior is unchanged.
+
+After this change:
+- `v16-scoring` loads `dist/v16.js` (MAX_SCORE 75), reaches a perfect score, and
+  passes.
+- `v01`–`v15` continue to pass (they have no `entry:` → default `index.js` → v17,
+  which is a cumulative superset, exactly as today).
+- Transcripts in other stories (dungeo, etc.) are unaffected — none set `entry:`.
+
+## Background — current wiring (verified)
+
+- `parser.ts:98` stores every header as `transcript.header[key] = value`, so
+  `entry` is **already parsed** into `transcript.header.entry`. Nothing reads it.
+- `types.ts` `TranscriptHeader` does not declare `entry`.
+- Two independent loaders, both hardcode `dist/index.js`:
+  - `story-loader.ts` `loadStory(storyPath)` — used by `cli.ts` (slow path).
+  - `fast-cli.ts` `loadStoryAndCreateGame(storyPath)` — used by the bundle
+    (`dist/cli/sharpee.js --test`, the fast/default path).
+- Both runners follow the same loop: load once before the loop, then per
+  transcript: `parseTranscriptFile` → (if `!chain`) reload story → `runTranscript`.
+  The parsed transcript — hence `header.entry` — is available at the reload point.
+
+## Design
+
+### 1. Shared entry resolution
+
+Add a single resolver (in `story-loader.ts`, exported, reused by both paths) so
+the two loaders cannot drift:
+
+```
+resolveStoryModulePath(storyPath, entry?) -> string
+  no entry      -> <storyPath>/dist/index.js          (current behavior)
+  entry given   -> first existing of:
+                     <storyPath>/dist/<entry>.js        (file form, e.g. v16)
+                     <storyPath>/dist/<entry>/index.js  (dir form, e.g. v17)
+                     <storyPath>/src/<entry>.ts         (ts-node fallback)
+                     <storyPath>/src/<entry>/index.ts
+  none exist    -> throw with the entry name and the paths tried
+```
+
+`entry` is validated as a safe relative segment (no `/`, `\`, `..`, or absolute
+paths) before being joined, so a transcript header cannot escape the story dir.
+
+### 2. Thread `entry` through both loaders
+
+- `loadStory(storyPath, entry?)` and `loadStoryAndCreateGame(storyPath, entry?)`
+  take an optional `entry`, call the resolver, and `require` the resolved path.
+  Existing call sites that pass no `entry` keep current behavior.
+- In both runners' per-transcript reload (the `if (!options.chain)` branch),
+  pass `transcript.header.entry`. This is the load-bearing change for familyzoo.
+
+### 3. `--chain` semantics
+
+In chain mode the story is loaded once and state persists; the story module
+cannot change between transcripts. Decision:
+- The initial pre-loop load uses the **first** transcript's `entry` (parse the
+  first transcript before the initial load, or honor entry only in non-chain and
+  ignore-with-warning in chain).
+- If any transcript in a chain declares an `entry` different from the loaded
+  module, emit a clear warning (or error under `--stop-on-failure`). Mixing
+  versions in a stateful chain is unsupported by design.
+- familyzoo's versioned transcripts are run individually (non-chain), so this is
+  an edge-case guard, not the primary path.
+
+### 4. Type + validation
+
+- `types.ts`: add `entry?: string` to `TranscriptHeader`.
+- `parser.ts` `validateTranscript`: optional — warn if `entry` is set but no
+  matching module is resolvable (the loader already errors; the warning just
+  surfaces it earlier).
+
+## Behavior Statement — `resolveStoryModulePath`
+
+- DOES: returns an absolute path to the story module to `require`, selecting
+  `dist/<entry>.js` or `dist/<entry>/index.js` when `entry` is supplied, else
+  `dist/index.js`.
+- WHEN: called by both loaders before `require`, with the transcript's
+  `header.entry` (or undefined).
+- BECAUSE: a versioned tutorial (familyzoo) ships multiple story entry points in
+  one package; a transcript must be able to pin the version it was authored for.
+- REJECTS WHEN: `entry` contains a path separator, `..`, or is absolute (throws,
+  not silently sanitized); or no candidate path exists (throws, listing tried
+  paths).
+
+## Tests (derived from the Behavior Statement)
+
+Unit (`story-loader` resolver):
+- entry `v16` resolves to `dist/v16.js` (file form).
+- entry `v17` resolves to `dist/v17/index.js` (dir form).
+- no entry resolves to `dist/index.js`.
+- entry `../x`, `a/b`, `/etc/x` each throw (traversal rejected).
+- nonexistent entry `v99` throws listing tried paths.
+
+Integration (the real-path acceptance gate):
+- Run the familyzoo transcript suite via both `cli.ts` and the bundle fast path:
+  - `v16-scoring` now **passes** (loads v16, max 75, perfect score).
+  - `v01`–`v15` still pass.
+- Run dungeo's suite unchanged (no `entry:`) — no regression.
+- `npm-test-familyzoo/run.sh` (after rebuilding the npm staging that bundles the
+  patched transcript-tester) reports 16/16.
+
+## Files to modify
+
+- `packages/transcript-tester/src/types.ts` — add `entry?: string` to header.
+- `packages/transcript-tester/src/story-loader.ts` — add `resolveStoryModulePath`;
+  `loadStory(storyPath, entry?)`.
+- `packages/transcript-tester/src/fast-cli.ts` — `loadStoryAndCreateGame(storyPath, entry?)`
+  using the shared resolver; thread entry at the per-transcript reload.
+- `packages/transcript-tester/src/cli.ts` — thread `transcript.header.entry` at
+  the per-transcript reload.
+- `packages/transcript-tester/src/parser.ts` — optional validation warning.
+- Tests under `packages/transcript-tester/tests/` (or `__tests__`).
+
+No familyzoo changes required — once `entry:` is honored, `v16-scoring` loads the
+version it was written for. (Optional follow-up: audit other familyzoo
+transcripts whose assertions diverge from v17.)
+
+## ADR recommendation
+
+Worth a short ADR (proposed **ADR-180**) — it establishes a test-authoring
+contract that constrains future story structure and tooling: *a transcript may
+pin a story sub-entry via `entry:`, resolved as `dist/<entry>.js` then
+`dist/<entry>/index.js`.* Decision/Context/Consequences are small; recommend
+filing alongside implementation.
+
+## Open questions
+
+1. **Chain + differing entries** — warn, or hard error? (Proposed: warn; error
+   under `--stop-on-failure`.)
+2. **Play mode `--entry` flag** — add a CLI `--entry` so `--play`/`--restore` can
+   target a version too? (Proposed: out of scope; add later if needed.)
+3. **ADR now or after** — file ADR-180 with the change, or land code first?
+
+## Rollback
+
+Additive and default-preserving: transcripts without `entry:` are byte-for-byte
+unaffected. Revert is the commit; no data/state migration.


### PR DESCRIPTION
## Summary

Design docs only — no code. Steps back from a run of build/test patches (the silent `.tsbuildinfo` no-op, dead `publish:beta`/`npm-latest.sh`, and the unimplemented `entry:` header that exposed **three hand-copied story loaders**) to productize the build/test layer as a self-tested devtool — the same "hard app" shape as DevArch.

## What's here

- **ADR-180** (PROPOSED) — `docs/architecture/adrs/adr-180-build-test-devkit.md`
- **Spec** with full per-decision rationale — `docs/work/sharpee-devkit/spec-20260617-build-test-devkit.md`
- **entry: plan** (folded into ADR-180 Phase 1) — `docs/work/transcript-entry-support/`
- Session summary addendum

## The decision (6 points, walked one at a time)

1. `@sharpee/devkit` at `tools/devkit` (internal) orchestrates; **tsf compiles**.
2. **Full replacement** of `build.sh`, parity-gated before deletion.
3. `@sharpee/bootstrap` (`packages/`, published) — the single entry-aware story loader. Kills the 3-loader duplication, ships the `entry:` fix. transcript-tester / bundle / devkit all depend on it (no cycle).
4. A story is a **location** — no committed config, no directory convention; `devkit init` registers name→path in user-level `~/.sharpee/devkit` memory (convenience only).
5. Targets: CLI bundle + browser + zifmia. **Dropped:** shite, `--runner`. **Deferred:** `.sharpee`.
6. Bundle kept as devkit's internal fast engine; `devkit` is the front door.

## Status

PROPOSED. Ran through `adr-review` → NEEDS WORK → folded six contract/AC tightenings (bootstrap API contract, atomic 3-loader update, enumerated edits, `~/.sharpee/devkit` format, docs-update AC, Phase-1 reclassification of registration) → **READY**. **Not accepted; no implementation started.**

Phase 1 when accepted: build `@sharpee/bootstrap` and route all three loaders through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)