### PR TITLE
ADR-180 Phase 3b: devkit browser target (byte-parity gated)

### DIFF
--- a/docs/context/session-20260618-0524-adr-180-phase3b-browser.md
+++ b/docs/context/session-20260618-0524-adr-180-phase3b-browser.md
@@ -1,0 +1,43 @@
+# Session Summary: 2026-06-18 (05:24 CST) — feat/adr-180-phase3b-browser
+
+## Goals
+- ADR-180 Phase 3b: `devkit build <story> --browser` — the self-contained browser
+  client (dist/web/<story>/), byte-parity with build.sh's `-c browser` (AC-9).
+
+## Context
+- Phase 3a (devkit build/bundle, CLI bundle) merged to main (PR #122).
+- Branch: feat/adr-180-phase3b-browser.
+
+## Completed
+- **`commands/browser.ts`** (`buildBrowserClient`): verbatim build.sh esbuild IIFE
+  (`--format=iife --global-name=SharpeeGame --minify --conditions=require`, single
+  platform-browser alias) → `dist/web/<story>/game.js`; copies index.html + base/
+  decorations/styles css + themes (rm -rf first) + story assets + website mirror;
+  asserts game.js non-empty.
+- **`--browser`** flag wired into `runBuild` (additive: implies `--esm`, requires a story,
+  runs after the CLI bundle) and the CLI.
+- **tsf robustness fix**: `devkit build` resolves `tsf` via `node_modules/.bin/tsf`
+  (build.sh's bare `tsf` fails when tsf is only a shell alias / not on a non-interactive
+  PATH). Identical compiler output; makes devkit work where build.sh's ESM pass wouldn't.
+- **Parity harness** `scripts/parity-browser.sh` — freezes version+date, wipes trees,
+  runs build.sh then devkit, byte-diffs the dist/web/<story> + website mirror trees.
+  (Puts node_modules/.bin on PATH so build.sh's bare tsf resolves.)
+- +2 rejection unit tests (`browser.test.ts`). devkit suite: **17 passing, 1 skipped**, GREEN.
+
+## Parity result
+- **PARITY PASS** — `dist/web/dungeo/` and `website/public/web/dungeo/` byte-identical to build.sh.
+- One real diff found + fixed en route: devkit copied a `.DS_Store` from `assets/` that
+  build.sh's `cp "$ASSETS_DIR"/*` glob skips. Fixed: skip dotfiles when copying story assets
+  (matches build.sh, and keeps Finder cruft out of the deliverable). Harness also now wipes
+  output trees between builders so a stale artifact can't mask a diff.
+
+## AC-9
+- Met: the IIFE `game.js` bakes platform + story into one payload — boots in a single load,
+  portable to any static host. Faithful port of build.sh's already-IIFE browser build.
+
+## Open / next
+- 3c — zifmia target (`pnpm --filter @sharpee/zifmia build` + BASELINE_VERSION).
+- 3d — cutover: delete build.sh + dead scripts; `devkit clean`/`verify`; umbrella wiring; AC-8 doc sweep.
+
+## Status
+- **Status**: COMPLETE (3b) — browser target implemented, 17 tests GREEN, byte-parity gate PASS.

--- a/packages/devkit/scripts/parity-browser.sh
+++ b/packages/devkit/scripts/parity-browser.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------
+# ADR-180 Phase 3b parity gate — browser client target.
+#
+# Proves `devkit build <story> --browser` produces a byte-identical
+# dist/web/<story>/ tree (and website mirror) to build.sh's
+# `-s <story> -c browser`, with version + build-date frozen (AC-5 / AC-9).
+# Run before deleting build.sh (Phase 3d).
+#
+# Usage: packages/devkit/scripts/parity-browser.sh [story]   (default: dungeo)
+# -------------------------------------------------------------------
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+# build.sh's ESM pass calls a bare `tsf`; ensure the workspace bin resolves even in a
+# non-interactive shell where `tsf` is only an alias. (devkit resolves it itself.)
+export PATH="$ROOT/node_modules/.bin:$PATH"
+
+STORY="${1:-dungeo}"
+FROZEN_VERSION="9.9.9-parity"
+FROZEN_DATE="2026-01-01T00:00:00Z"
+TREES=("dist/web/${STORY}" "website/public/web/${STORY}")
+SNAP="$(mktemp -d)"
+trap 'rm -rf "$SNAP"; git checkout -q -- "stories/${STORY}/src/version.ts" packages/sharpee/package.json 2>/dev/null || true' EXIT
+
+# Write a sorted "relpath  sha256" manifest for a tree (skips if absent).
+manifest() {
+  local tree="$1" out="$2"
+  if [ -d "$tree" ]; then
+    ( cd "$tree" && find . -type f -print0 | sort -z | xargs -0 shasum -a 256 ) > "$out"
+  else
+    : > "$out"
+  fi
+}
+
+snapshot() {
+  local tag="$1"
+  for t in "${TREES[@]}"; do
+    manifest "$t" "$SNAP/$tag-$(echo "$t" | tr / _).manifest"
+  done
+}
+
+# Wipe the output trees before each builder so a stale artifact can't mask a diff.
+clean_trees() { for t in "${TREES[@]}"; do rm -rf "$t"; done; }
+
+echo "=== [1/3] build.sh -s ${STORY} -c browser (frozen) ==="
+clean_trees
+BUILD_DATE_OVERRIDE="$FROZEN_DATE" ./build.sh -s "$STORY" -c browser --version "$FROZEN_VERSION"
+snapshot buildsh
+
+echo "=== [2/3] devkit build ${STORY} --browser (frozen) ==="
+clean_trees
+node packages/devkit/dist/cli.js build "$STORY" --browser --version "$FROZEN_VERSION" --build-date "$FROZEN_DATE"
+snapshot devkit
+
+echo "=== [3/3] diff ==="
+FAIL=0
+for t in "${TREES[@]}"; do
+  key=$(echo "$t" | tr / _)
+  if diff -u "$SNAP/buildsh-$key.manifest" "$SNAP/devkit-$key.manifest"; then
+    echo "  OK   $t"
+  else
+    echo "  DIFF $t"
+    FAIL=1
+  fi
+done
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "PARITY PASS — devkit browser build matches build.sh byte-for-byte (${STORY})."
+else
+  echo "PARITY FAIL — see diff above."
+  exit 1
+fi

--- a/packages/devkit/src/cli.ts
+++ b/packages/devkit/src/cli.ts
@@ -27,6 +27,7 @@ build options:
   --no-genai              Skip genai-api generation
   --no-bundle             Build packages/story but skip the CLI bundle step
   --esm                   Also run the ESM build pass (browser/story-bundle targets)
+  --browser               Also build the self-contained browser client (dist/web/<story>/; requires a story)
 
 test:npm options:
   --local                 Install the @sharpee closure from local staging (~/.tsf-publish) [default]
@@ -53,6 +54,7 @@ function parseBuild(args: string[]): BuildOptions {
     else if (a === '--no-genai') opts.noGenai = true;
     else if (a === '--no-bundle') opts.bundle = false;
     else if (a === '--esm') opts.esm = true;
+    else if (a === '--browser') opts.browser = true;
     else if (a.startsWith('-')) throw new Error(`unknown option: ${a}`);
     else if (!opts.story) opts.story = a;
     else throw new Error(`unexpected argument: ${a}`);

--- a/packages/devkit/src/commands/browser.test.ts
+++ b/packages/devkit/src/commands/browser.test.ts
@@ -1,0 +1,26 @@
+/**
+ * browser.test.ts — rejection-path unit tests for the browser client build.
+ * Byte-for-byte parity with build.sh is covered by scripts/parity-browser.sh.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildBrowserClient } from './browser';
+
+describe('buildBrowserClient rejection paths', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'devkit-browser-'));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('throws when the story does not exist', () => {
+    expect(() => buildBrowserClient(root, 'nope', { quiet: true })).toThrow(/story not found/);
+  });
+
+  it('throws when the story has no browser-entry.ts', () => {
+    mkdirSync(join(root, 'stories', 'foo', 'src'), { recursive: true });
+    expect(() => buildBrowserClient(root, 'foo', { quiet: true })).toThrow(/browser entry not found/);
+  });
+});

--- a/packages/devkit/src/commands/browser.ts
+++ b/packages/devkit/src/commands/browser.ts
@@ -1,0 +1,112 @@
+/**
+ * browser.ts — `devkit build <story> --browser`: the self-contained single-player
+ * web app at dist/web/<story>/ (build.sh build_browser_client, 877-952).
+ *
+ * Owner context: @sharpee/devkit (ADR-180 Phase 3b). The author's player-facing
+ * deliverable (AC-9): an IIFE game.js + css + html that boots in one load, portable
+ * to any static host. Byte-for-byte parity with build.sh until the 3d cutover.
+ *
+ * Public interface: buildBrowserClient(root, story, opts) -> void.
+ */
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveStoryDir } from '../repo';
+
+export interface BrowserBuildOptions {
+  quiet?: boolean;
+}
+
+/** Copy a template file if present (build.sh's per-file `if [ -f ]` copies). */
+function copyIfExists(src: string, dest: string): boolean {
+  if (!existsSync(src)) return false;
+  cpSync(src, dest);
+  return true;
+}
+
+/**
+ * Build the browser client for `story` into dist/web/<story>/. Assumes platform +
+ * story (incl. ESM where applicable) are already built.
+ * @throws if the story or its browser-entry.ts is missing, or game.js is empty after esbuild.
+ */
+export function buildBrowserClient(root: string, story: string, opts: BrowserBuildOptions = {}): void {
+  const log = (m: string) => !opts.quiet && console.log(m);
+  const storyDir = resolveStoryDir(root, story);
+  if (!storyDir) throw new Error(`story not found: ${story}`);
+  const entry = join(storyDir, 'src', 'browser-entry.ts');
+  if (!existsSync(entry)) throw new Error(`browser entry not found: ${entry}`);
+
+  const outRel = join('dist', 'web', story);
+  const outDir = join(root, outRel);
+  mkdirSync(outDir, { recursive: true });
+  log(`=== Building Browser Client: ${story} ===`);
+
+  // Bundle — verbatim build.sh esbuild invocation (single platform-browser alias; the
+  // IIFE bakes the platform + story into one payload, so the page boots in a single load).
+  execFileSync(
+    'npx',
+    [
+      'esbuild',
+      join(storyDir, 'src', 'browser-entry.ts'),
+      '--bundle',
+      '--platform=browser',
+      '--target=es2020',
+      '--format=iife',
+      '--global-name=SharpeeGame',
+      `--outfile=${join(outRel, 'game.js')}`,
+      '--sourcemap',
+      '--minify',
+      '--conditions=require',
+      '--define:process.env.PARSER_DEBUG=undefined',
+      '--define:process.env.DEBUG_PRONOUNS=undefined',
+      '--define:process.env.NODE_ENV="production"',
+      `--alias:@sharpee/platform-browser=${join(root, 'packages', 'platform-browser', 'dist', 'index.js')}`,
+    ],
+    { cwd: root, stdio: opts.quiet ? 'ignore' : 'inherit' },
+  );
+
+  const tpl = join(root, 'templates', 'browser');
+  // index.html (title set at runtime by BrowserClient from story config).
+  copyIfExists(join(tpl, 'index.html'), join(outDir, 'index.html'));
+  // CSS: base (structural, ADR-170), decorations (prose vocabulary, ADR-174), infocom→styles (theme).
+  copyIfExists(join(tpl, 'base.css'), join(outDir, 'base.css'));
+  copyIfExists(join(tpl, 'decorations.css'), join(outDir, 'decorations.css'));
+  copyIfExists(join(tpl, 'infocom.css'), join(outDir, 'styles.css'));
+  // Theme assets (per-theme bundled webfonts). rm -rf first to avoid cp-into-existing nesting.
+  if (existsSync(join(tpl, 'themes'))) {
+    rmSync(join(outDir, 'themes'), { recursive: true, force: true });
+    cpSync(join(tpl, 'themes'), join(outDir, 'themes'), { recursive: true });
+  }
+
+  // Story assets (audio, images): copy the contents of <story>/assets/ into the output.
+  // Skip dotfiles to match build.sh's `cp "$ASSETS_DIR"/*` (bash glob excludes dotfiles,
+  // so .DS_Store and friends never reach the deliverable).
+  const assetsDir = join(storyDir, 'assets');
+  if (existsSync(assetsDir)) {
+    for (const entryName of readdirSync(assetsDir)) {
+      if (entryName.startsWith('.')) continue;
+      cpSync(join(assetsDir, entryName), join(outDir, entryName), { recursive: true });
+    }
+  }
+
+  // Website mirror.
+  if (existsSync(join(root, 'website', 'public'))) {
+    const webDir = join(root, 'website', 'public', 'web', story);
+    mkdirSync(webDir, { recursive: true });
+    cpSync(join(outDir, 'game.js'), join(webDir, 'game.js'));
+    if (existsSync(join(outDir, 'index.html'))) cpSync(join(outDir, 'index.html'), join(webDir, 'index.html'));
+    if (existsSync(join(outDir, 'base.css'))) cpSync(join(outDir, 'base.css'), join(webDir, 'base.css'));
+    if (existsSync(join(outDir, 'styles.css'))) cpSync(join(outDir, 'styles.css'), join(webDir, 'styles.css'));
+    if (existsSync(join(outDir, 'themes'))) {
+      rmSync(join(webDir, 'themes'), { recursive: true, force: true });
+      cpSync(join(outDir, 'themes'), join(webDir, 'themes'), { recursive: true });
+    }
+  }
+
+  // Invariant: assert the deliverable exists (no silent success on an empty build).
+  const gameJs = join(outDir, 'game.js');
+  if (!existsSync(gameJs) || statSync(gameJs).size === 0) {
+    throw new Error(`browser build failed: ${join(outRel, 'game.js')} is missing or empty`);
+  }
+  log(`Output: ${outRel}/ (${statSync(gameJs).size} bytes)`);
+}

--- a/packages/devkit/src/commands/build.ts
+++ b/packages/devkit/src/commands/build.ts
@@ -19,6 +19,7 @@ import {
   storyVersionFile,
 } from '../repo';
 import { runBundle } from './bundle';
+import { buildBrowserClient } from './browser';
 
 /**
  * The generator name written into stamped version.ts files. Verbatim "build.sh" so
@@ -44,11 +45,23 @@ export interface BuildOptions {
   esm?: boolean;
   /** Run the bundle step at the end (default true — the full build.sh pipeline). */
   bundle?: boolean;
+  /** Also build the browser client (dist/web/<story>/). Implies --esm; requires a story. */
+  browser?: boolean;
   quiet?: boolean;
 }
 
 function nowStamp(): string {
   return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * Resolve the `tsf` executable. Prefers the workspace-local `node_modules/.bin/tsf`
+ * (build.sh relies on a bare `tsf`, which fails when tsf is only a shell alias);
+ * falls back to `tsf` on PATH. Produces identical compiler output either way.
+ */
+function tsfBin(root: string): string {
+  const local = join(root, 'node_modules', '.bin', 'tsf');
+  return existsSync(local) ? local : 'tsf';
 }
 
 /** Rewrite a package.json's version, preserving key order + 2-space indent + trailing newline. */
@@ -123,7 +136,7 @@ export function buildPlatform(root: string, opts: BuildOptions): void {
       }
       if (existsSync(join(root, 'packages', dir, 'tsconfig.esm.json'))) {
         // tsf drives the esm target so esmExtensions post-processing runs (build.sh comment 555-557).
-        run('tsf', ['build', '--condition', 'esm', '--filter', pkg]);
+        run(tsfBin(root), ['build', '--condition', 'esm', '--filter', pkg]);
       }
     }
   }
@@ -147,7 +160,7 @@ export function buildStory(root: string, story: string, opts: BuildOptions): voi
     stdio: opts.quiet ? 'ignore' : 'inherit',
   });
   if (opts.esm && existsSync(join(dir, 'tsconfig.esm.json'))) {
-    execFileSync('tsf', ['build', '--condition', 'esm', '--filter', pkg], {
+    execFileSync(tsfBin(root), ['build', '--condition', 'esm', '--filter', pkg], {
       cwd: root,
       stdio: opts.quiet ? 'ignore' : 'inherit',
     });
@@ -159,12 +172,17 @@ export function runBuild(opts: BuildOptions = {}): void {
   const root = opts.root ?? findRepoRoot();
   const log = (m: string) => !opts.quiet && console.log(m);
 
+  // The browser client target needs the ESM build pass (build.sh runs it when a client is requested).
+  const effective: BuildOptions = opts.browser ? { ...opts, esm: true } : opts;
+  if (effective.browser && !effective.story) throw new Error('--browser requires a story');
+
   log('=== devkit build ===');
-  const version = stampVersions(root, opts);
-  log(`version: ${version}${opts.story ? ` · story: ${opts.story}` : ''}`);
-  buildPlatform(root, opts);
-  if (!opts.noGenai) generateGenaiApi(root, opts);
-  if (opts.story) buildStory(root, opts.story, opts);
-  if (opts.bundle !== false) runBundle({ root, quiet: opts.quiet });
+  const version = stampVersions(root, effective);
+  log(`version: ${version}${effective.story ? ` · story: ${effective.story}` : ''}`);
+  buildPlatform(root, effective);
+  if (!effective.noGenai) generateGenaiApi(root, effective);
+  if (effective.story) buildStory(root, effective.story, effective);
+  if (effective.bundle !== false) runBundle({ root, quiet: effective.quiet });
+  if (effective.browser) buildBrowserClient(root, effective.story!, { quiet: effective.quiet });
   log('=== build complete ===');
 }

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -12,6 +12,8 @@ export { runBuild, stampVersions, buildPlatform, generateGenaiApi, buildStory } 
 export type { BuildOptions } from './commands/build';
 export { runBundle } from './commands/bundle';
 export type { BundleOptions } from './commands/bundle';
+export { buildBrowserClient } from './commands/browser';
+export type { BrowserBuildOptions } from './commands/browser';
 export {
   findRepoRoot,
   resolveStoryDir,


### PR DESCRIPTION
## What

ADR-180 **Phase 3b** — `devkit build <story> --browser` produces the self-contained single-player browser client at `dist/web/<story>/` (build.sh `build_browser_client`). build.sh stays primary until the 3d cutover.

## How

- **`commands/browser.ts`** (`buildBrowserClient`): verbatim build.sh esbuild IIFE (`--format=iife --global-name=SharpeeGame --minify --conditions=require`, single `@sharpee/platform-browser` alias) → `game.js`; copies `index.html` + base/decorations/styles CSS + themes (rm -rf first) + story assets + website mirror; asserts `game.js` non-empty.
- **`--browser`** wired into `runBuild` (additive: implies `--esm`, requires a story, runs after the CLI bundle) and the CLI.
- **tsf robustness:** `devkit build` resolves `tsf` via `node_modules/.bin/tsf` — build.sh's bare `tsf` fails when tsf is only a shell alias / not on a non-interactive PATH. Identical compiler output, more robust.
- **`scripts/parity-browser.sh`**: the AC-5/AC-9 gate — wipes trees, freezes version+date, byte-diffs `dist/web/<story>` + website mirror.

## Parity (byte-identical)

**Full harness (two real browser builds): PARITY PASS** — `dist/web/dungeo/` and `website/public/web/dungeo/` byte-identical to build.sh.

One real diff found + fixed en route: devkit copied a `.DS_Store` from `assets/` that build.sh's `cp "$ASSETS_DIR"/*` glob skips → now skips dotfiles (matches build.sh, keeps Finder cruft out). Harness also wipes trees between builders so a stale artifact can't mask a diff.

## AC-9

Met — the IIFE `game.js` bakes platform + story into one payload that boots in a single load, portable to any static host.

## Tests

+2 rejection unit tests. devkit suite: **17 passing, 1 skipped**, GREEN.

## Next

3c (zifmia target), 3d (cutover: delete build.sh + dead scripts, `devkit clean`/`verify`, umbrella wiring, AC-8 doc sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)