### PR TITLE
ADR-180 Phase 3c: devkit zifmia target (byte-parity gated)

### DIFF
--- a/docs/context/session-20260618-0531-adr-180-phase3c-zifmia.md
+++ b/docs/context/session-20260618-0531-adr-180-phase3c-zifmia.md
@@ -1,0 +1,35 @@
+# Session Summary: 2026-06-18 (05:31 CST) — feat/adr-180-phase3c-zifmia
+
+## Goals
+- ADR-180 Phase 3c: `devkit build --zifmia` — the multi-user server (tools/zifmia/dist),
+  byte-parity with build.sh's `-c zifmia`.
+
+## Context
+- Phase 3b (browser target) merged to main (PR #123). Branch: feat/adr-180-phase3c-zifmia.
+
+## Completed
+- **`commands/zifmia.ts`** (`buildZifmiaServer`): runs `pnpm --filter @sharpee/zifmia build`
+  verbatim (devkit invokes zifmia's own build, doesn't reimplement it), surfaces the Story
+  Runtime Baseline version (docker `--build-arg`), asserts `tools/zifmia/dist`. Per ADR-180
+  the `.sharpee` bundle is deferred — this target does not build one.
+- **`--zifmia`** wired into `runBuild` (implies `--esm`, no story required, runs after the
+  CLI bundle) and the CLI. `stampVersions` now stamps `tools/zifmia/package.json` for `--zifmia`.
+- **Parity harness** `scripts/parity-zifmia.sh` — byte-diffs `tools/zifmia/dist` + the version
+  stamp. zifmia's build verified **deterministic** (two consecutive builds → identical tree
+  sha), so a full dist byte-diff is a valid strong gate (despite Vite content-hashed assets).
+- +1 rejection unit test (`zifmia.test.ts`). devkit suite: **18 passing, 1 skipped**, GREEN.
+
+## Parity result
+- **PARITY PASS** — `tools/zifmia/dist` and `tools/zifmia/package.json` version byte-identical to build.sh.
+
+## Phase 3 target status
+- ✅ 3a CLI bundle (PR #122), ✅ 3b browser (PR #123), ✅ 3c zifmia — **all three live targets byte-parity gated.**
+
+## Open / next — 3d cutover (IRREVERSIBLE; needs explicit confirmation)
+- Delete build.sh + dead scripts; `devkit clean`/`verify`; `@sharpee/sharpee`→devkit umbrella
+  wiring; AC-8 doc sweep (CLAUDE.md + package CLAUDE.md + docs/ → devkit equivalents); flip the
+  version.ts GENERATOR const from "build.sh" to "devkit". Run all three parity harnesses green
+  one last time immediately before deleting build.sh.
+
+## Status
+- **Status**: COMPLETE (3c) — zifmia target implemented, 18 tests GREEN, byte-parity gate PASS.

--- a/packages/devkit/scripts/parity-zifmia.sh
+++ b/packages/devkit/scripts/parity-zifmia.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------
+# ADR-180 Phase 3c parity gate — zifmia (multi-user server) target.
+#
+# Proves `devkit build --zifmia` produces a byte-identical tools/zifmia/dist
+# tree and version stamp to build.sh's `-c zifmia`, with version frozen (AC-5).
+# (zifmia's own build is deterministic — verified — so a full byte-diff is valid.)
+# Per ADR-180 the .sharpee story bundle is deferred; neither path builds one.
+# Run before deleting build.sh (Phase 3d).
+#
+# Usage: packages/devkit/scripts/parity-zifmia.sh
+# -------------------------------------------------------------------
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+# build.sh's ESM pass calls a bare `tsf`; ensure the workspace bin resolves.
+export PATH="$ROOT/node_modules/.bin:$PATH"
+
+FROZEN_VERSION="9.9.9-parity"
+FROZEN_DATE="2026-01-01T00:00:00Z"
+SNAP="$(mktemp -d)"
+trap 'rm -rf "$SNAP"; git checkout -q -- tools/zifmia/package.json packages/sharpee/package.json 2>/dev/null || true' EXIT
+
+dist_manifest() {
+  ( cd tools/zifmia/dist && find . -type f -print0 | sort -z | xargs -0 shasum -a 256 ) > "$1"
+}
+pkg_version() {
+  node -p "require('./tools/zifmia/package.json').version" > "$1"
+}
+
+echo "=== [1/3] build.sh -c zifmia (frozen) ==="
+rm -rf tools/zifmia/dist
+BUILD_DATE_OVERRIDE="$FROZEN_DATE" ./build.sh -c zifmia --version "$FROZEN_VERSION"
+dist_manifest "$SNAP/buildsh-dist.manifest"
+pkg_version "$SNAP/buildsh-pkg.version"
+
+echo "=== [2/3] devkit build --zifmia (frozen) ==="
+rm -rf tools/zifmia/dist
+node packages/devkit/dist/cli.js build --zifmia --version "$FROZEN_VERSION" --build-date "$FROZEN_DATE"
+dist_manifest "$SNAP/devkit-dist.manifest"
+pkg_version "$SNAP/devkit-pkg.version"
+
+echo "=== [3/3] diff ==="
+FAIL=0
+if diff -u "$SNAP/buildsh-dist.manifest" "$SNAP/devkit-dist.manifest"; then
+  echo "  OK   tools/zifmia/dist"
+else
+  echo "  DIFF tools/zifmia/dist"
+  FAIL=1
+fi
+if diff -q "$SNAP/buildsh-pkg.version" "$SNAP/devkit-pkg.version" > /dev/null; then
+  echo "  OK   tools/zifmia/package.json version"
+else
+  echo "  DIFF tools/zifmia/package.json version"
+  FAIL=1
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "PARITY PASS — devkit zifmia build matches build.sh byte-for-byte."
+else
+  echo "PARITY FAIL — see diff above."
+  exit 1
+fi

--- a/packages/devkit/src/cli.ts
+++ b/packages/devkit/src/cli.ts
@@ -28,6 +28,7 @@ build options:
   --no-bundle             Build packages/story but skip the CLI bundle step
   --esm                   Also run the ESM build pass (browser/story-bundle targets)
   --browser               Also build the self-contained browser client (dist/web/<story>/; requires a story)
+  --zifmia                Also build the zifmia multi-user server (tools/zifmia/dist/)
 
 test:npm options:
   --local                 Install the @sharpee closure from local staging (~/.tsf-publish) [default]
@@ -55,6 +56,7 @@ function parseBuild(args: string[]): BuildOptions {
     else if (a === '--no-bundle') opts.bundle = false;
     else if (a === '--esm') opts.esm = true;
     else if (a === '--browser') opts.browser = true;
+    else if (a === '--zifmia') opts.zifmia = true;
     else if (a.startsWith('-')) throw new Error(`unknown option: ${a}`);
     else if (!opts.story) opts.story = a;
     else throw new Error(`unexpected argument: ${a}`);

--- a/packages/devkit/src/commands/build.ts
+++ b/packages/devkit/src/commands/build.ts
@@ -20,6 +20,7 @@ import {
 } from '../repo';
 import { runBundle } from './bundle';
 import { buildBrowserClient } from './browser';
+import { buildZifmiaServer } from './zifmia';
 
 /**
  * The generator name written into stamped version.ts files. Verbatim "build.sh" so
@@ -47,6 +48,8 @@ export interface BuildOptions {
   bundle?: boolean;
   /** Also build the browser client (dist/web/<story>/). Implies --esm; requires a story. */
   browser?: boolean;
+  /** Also build the zifmia multi-user server (tools/zifmia/dist/). Implies --esm. */
+  zifmia?: boolean;
   quiet?: boolean;
 }
 
@@ -104,6 +107,12 @@ export const VERSION_INFO = { version: STORY_VERSION, buildDate: BUILD_DATE, eng
 `,
       );
     }
+  }
+
+  // zifmia package.json version (build.sh update_versions stamps it for -c zifmia).
+  if (opts.zifmia) {
+    const zifmiaPkg = join(root, 'tools', 'zifmia', 'package.json');
+    if (existsSync(zifmiaPkg)) writePkgVersion(zifmiaPkg, sharpeeVersion);
   }
   return sharpeeVersion;
 }
@@ -172,8 +181,8 @@ export function runBuild(opts: BuildOptions = {}): void {
   const root = opts.root ?? findRepoRoot();
   const log = (m: string) => !opts.quiet && console.log(m);
 
-  // The browser client target needs the ESM build pass (build.sh runs it when a client is requested).
-  const effective: BuildOptions = opts.browser ? { ...opts, esm: true } : opts;
+  // Client targets (browser/zifmia) need the ESM build pass (build.sh runs it when a client is requested).
+  const effective: BuildOptions = opts.browser || opts.zifmia ? { ...opts, esm: true } : opts;
   if (effective.browser && !effective.story) throw new Error('--browser requires a story');
 
   log('=== devkit build ===');
@@ -184,5 +193,6 @@ export function runBuild(opts: BuildOptions = {}): void {
   if (effective.story) buildStory(root, effective.story, effective);
   if (effective.bundle !== false) runBundle({ root, quiet: effective.quiet });
   if (effective.browser) buildBrowserClient(root, effective.story!, { quiet: effective.quiet });
+  if (effective.zifmia) buildZifmiaServer(root, { quiet: effective.quiet });
   log('=== build complete ===');
 }

--- a/packages/devkit/src/commands/zifmia.test.ts
+++ b/packages/devkit/src/commands/zifmia.test.ts
@@ -1,0 +1,17 @@
+/**
+ * zifmia.test.ts — rejection-path unit test for the zifmia server build.
+ * Byte-for-byte parity with build.sh is covered by scripts/parity-zifmia.sh.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildZifmiaServer } from './zifmia';
+
+describe('buildZifmiaServer rejection paths', () => {
+  it('throws when tools/zifmia is absent', () => {
+    const root = mkdtempSync(join(tmpdir(), 'devkit-zifmia-'));
+    expect(() => buildZifmiaServer(root, { quiet: true })).toThrow(/tools\/zifmia not found/);
+    rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/devkit/src/commands/zifmia.ts
+++ b/packages/devkit/src/commands/zifmia.ts
@@ -1,0 +1,57 @@
+/**
+ * zifmia.ts — `devkit build --zifmia`: build the corrected multi-user server
+ * (ADR-177) at tools/zifmia/ (build.sh build_zifmia_server, 996-1032).
+ *
+ * Owner context: @sharpee/devkit (ADR-180 Phase 3c). devkit invokes the zifmia
+ * package's own build verbatim (`pnpm --filter @sharpee/zifmia build`) — it does
+ * not reimplement it. Per ADR-180 the `.sharpee` story bundle is deferred, so this
+ * target does not build one.
+ *
+ * Public interface: buildZifmiaServer(root, opts) -> void.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface ZifmiaBuildOptions {
+  quiet?: boolean;
+}
+
+/**
+ * Build the zifmia server and surface the Story Runtime Baseline version (for the
+ * operator's `docker build --build-arg BASELINE_VERSION=`).
+ * @throws if tools/zifmia is absent or the build produces no dist/.
+ */
+export function buildZifmiaServer(root: string, opts: ZifmiaBuildOptions = {}): void {
+  const log = (m: string) => !opts.quiet && console.log(m);
+  const zifmiaDir = join(root, 'tools', 'zifmia');
+  if (!existsSync(zifmiaDir)) throw new Error('tools/zifmia not found');
+
+  log('=== Building zifmia (multi-user server, ADR-177) ===');
+  execFileSync('pnpm', ['--filter', '@sharpee/zifmia', 'build'], {
+    cwd: root,
+    stdio: opts.quiet ? 'ignore' : 'inherit',
+  });
+
+  // ADR-178 §AC-3: surface the baseline version sourced from the built manifest.
+  const baselineMod = join(root, 'packages', 'story-runtime-baseline', 'dist', 'index.js');
+  if (existsSync(baselineMod)) {
+    try {
+      const ver = execFileSync('node', ['-p', `require(${JSON.stringify(baselineMod)}).BASELINE_VERSION`], {
+        cwd: root,
+        encoding: 'utf8',
+      }).trim();
+      if (ver) {
+        log(`Story Runtime Baseline: v${ver}`);
+        log(`  (docker build expects --build-arg BASELINE_VERSION=${ver}; docker-compose.yml does this automatically)`);
+      }
+    } catch {
+      /* baseline version is informational only — never fail the build over it */
+    }
+  }
+
+  // Invariant: assert the server dist exists (no silent success).
+  const dist = join(zifmiaDir, 'dist');
+  if (!existsSync(dist)) throw new Error('zifmia build produced no tools/zifmia/dist/');
+  log('Output: tools/zifmia/dist/');
+}

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -14,6 +14,8 @@ export { runBundle } from './commands/bundle';
 export type { BundleOptions } from './commands/bundle';
 export { buildBrowserClient } from './commands/browser';
 export type { BrowserBuildOptions } from './commands/browser';
+export { buildZifmiaServer } from './commands/zifmia';
+export type { ZifmiaBuildOptions } from './commands/zifmia';
 export {
   findRepoRoot,
   resolveStoryDir,


### PR DESCRIPTION
## What

ADR-180 **Phase 3c** — `devkit build --zifmia` builds the ADR-177 multi-user server at `tools/zifmia/dist` (build.sh `build_zifmia_server`). This completes the **three live build targets**; build.sh stays primary until the 3d cutover.

## How

- **`commands/zifmia.ts`** (`buildZifmiaServer`): runs `pnpm --filter @sharpee/zifmia build` **verbatim** (devkit invokes zifmia's own build, doesn't reimplement it), surfaces the Story Runtime Baseline version for the operator's `docker build --build-arg`, asserts `tools/zifmia/dist`. Per ADR-180 the `.sharpee` bundle is **deferred** — this target does not build one.
- **`--zifmia`** wired into `runBuild` (implies `--esm`, no story required, runs after the CLI bundle) and the CLI; `stampVersions` stamps `tools/zifmia/package.json`.
- **`scripts/parity-zifmia.sh`**: byte-diffs `tools/zifmia/dist` + version stamp. zifmia's build verified **deterministic** (two consecutive builds → identical tree sha, despite Vite content-hashed assets), so a full dist byte-diff is a valid strong gate.

## Parity (byte-identical)

**Full harness (two real builds): PARITY PASS** — `tools/zifmia/dist` and `tools/zifmia/package.json` version byte-identical to build.sh.

## Phase 3 status

✅ 3a CLI bundle (#122) · ✅ 3b browser (#123) · ✅ 3c zifmia — **all three live targets are byte-parity gated against build.sh.**

## Tests

+1 rejection unit test. devkit suite: **18 passing, 1 skipped**, GREEN.

## Next — 3d cutover (IRREVERSIBLE)

Delete build.sh + dead scripts; `devkit clean`/`verify`; `@sharpee/sharpee`→devkit umbrella wiring; AC-8 doc sweep; flip the version.ts `GENERATOR` const "build.sh"→"devkit". All three parity harnesses run green one last time immediately before deletion. **Will stop for explicit confirmation before this phase.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)