### PR TITLE
ADR-180 Phase U3: location registry + standalone-build harness

### DIFF
--- a/docs/context/session-20260618-0600-adr-180-unify-cli-design.md
+++ b/docs/context/session-20260618-0600-adr-180-unify-cli-design.md
@@ -63,4 +63,20 @@ U2** (atomic), and **U1 is the non-breaking repo-ergonomics increment**:
     routing from an out-of-repo dir → standalone build path.
   - **Remaining real-path gap (flagged):** a full standalone `sharpee build` e2e (out-of-repo
     project → `.sharpee`) not yet run; the moved code is the previously-shipped sharpee CLI.
-- **Status**: U2 COMPLETE pending standalone e2e; U3 (register/list + `bundle:story` verb) next.
+- **U2** merged (PR #127).
+- **Standalone harness** (closes the U2 real-path gap): gated `standalone-build.test.ts` stands
+  up an out-of-repo consumer (local-staging tarballs) and runs the production `node dist/cli.js
+  build` in standalone mode. **Executed (DEVKIT_INTEGRATION=1): PASS** — compiled + emitted
+  `dist/*.sharpee` (8.1 KB). Standalone path proven e2e.
+- **U3** implemented on `feat/adr-180-u3-register-and-harness`:
+  - `registry.ts` — the `~/.sharpee/devkit` location registry (ADR format
+    `{stories:{<name>:{path}}}`; `SHARPEE_DEVKIT_REGISTRY` override for tests). read/register/
+    list/lookup; stale paths throw on lookup (never silently skipped), flagged by `list`.
+  - `sharpee register <location> [--name]` + `sharpee list` (commands/register.ts), wired.
+  - Registered-name resolution: standalone `sharpee build <name>` builds at the registered
+    path (standalone build/build-browser gained a `projectDir` param); `sharpee test:npm <name>`
+    resolves a registered name → path (closes ADR AC-3 "test <name> after register").
+  - +6 registry unit tests (30 passing, 2 gated-skipped). Smoked register/list via the CLI.
+  - **Deferred:** a dedicated `bundle:story` verb (`.sharpee` already produced by standalone
+    `build`); `sharpee update` self-update.
+- **Status**: U1/U2/U3 + standalone harness COMPLETE. ADR-180 unify track delivered.

--- a/packages/devkit/src/cli.ts
+++ b/packages/devkit/src/cli.ts
@@ -21,6 +21,9 @@ import { runBuildBrowserCommand } from './standalone/build-browser';
 import { runInitCommand } from './standalone/init';
 import { runInitBrowserCommand } from './standalone/init-browser';
 import { runIfidCommand } from './standalone/ifid';
+import { runRegister, runList } from './commands/register';
+import { lookupStory } from './registry';
+import { existsSync } from 'node:fs';
 
 const USAGE = `sharpee — Interactive Fiction build/test/scaffold CLI (ADR-180)
 
@@ -33,7 +36,9 @@ Usage:
   sharpee bundle                         (monorepo) Assemble dist/cli/sharpee.js
   sharpee clean                          Remove build artifacts (dist, dist-esm, tsbuildinfo)
   sharpee verify                         tsf build --npm + publish dry-run
-  sharpee test:npm <location> [options]  Stand up an npm consumer for a story and run its transcripts
+  sharpee test:npm <loc|name> [options]  Stand up an npm consumer for a story and run its transcripts
+  sharpee register <location> [--name]   Register a name→path mapping in ~/.sharpee/devkit
+  sharpee list                           List registered stories
 
 build (monorepo) options:
   [story|path]            In-repo story name or path (stories/<n>, tutorials/<n>, or a directory)
@@ -49,7 +54,7 @@ test:npm options:
   --local [default] | --registry | --version <range> | --staging <dir>
   --transcripts <glob> | --chain | --quick | --keep
 
-Reserved (later): test, play, register, list`;
+Reserved (later): test, play, bundle:story`;
 
 /** Parse the monorepo `build` flags (positional [story] + options). */
 function parseBuild(args: string[]): BuildOptions {
@@ -108,11 +113,22 @@ async function main(argv: string[]): Promise<number> {
     case 'build': {
       if (detectMode() === 'monorepo') {
         runBuild(parseBuild(rest));
-      } else if (rest.includes('--browser')) {
-        await runBuildBrowserCommand(rest.filter((a) => a !== '--browser'));
-      } else {
-        await runBuildCommand(rest); // standalone: compile + .sharpee + browser (+ --test)
+        return 0;
       }
+      // Standalone: build the cwd project, or a registered story by name.
+      const positional = rest.find((a) => !a.startsWith('-'));
+      const flags = rest.filter((a) => a !== positional);
+      let dir: string | undefined;
+      if (positional) {
+        dir = lookupStory(positional) ?? undefined; // throws if registered-but-stale
+        if (!dir) {
+          throw new Error(
+            `'${positional}' is not a registered story — run \`sharpee register <location>\`, or run \`sharpee build\` from the project directory`,
+          );
+        }
+      }
+      if (flags.includes('--browser')) await runBuildBrowserCommand(flags.filter((a) => a !== '--browser'), dir);
+      else await runBuildCommand(flags, dir);
       return 0;
     }
     case 'build-browser': {
@@ -139,7 +155,10 @@ async function main(argv: string[]): Promise<number> {
       runVerify({});
       return 0;
     case 'test:npm': {
-      const r = runTestNpm(parseTestNpm(rest));
+      const opts = parseTestNpm(rest);
+      // Resolve a registered story name → its path (so `test:npm <name>` works; ADR AC-3).
+      if (!existsSync(opts.location)) opts.location = lookupStory(opts.location) ?? opts.location;
+      const r = runTestNpm(opts);
       if (!r.ran) return 0;
       console.log('===========================================');
       console.log(`  RESULTS: ${r.passed} passing, ${r.failed} failures`);
@@ -150,10 +169,14 @@ async function main(argv: string[]): Promise<number> {
       }
       return 0;
     }
+    case 'register':
+      runRegister(rest);
+      return 0;
+    case 'list':
+      runList();
+      return 0;
     case 'test':
     case 'play':
-    case 'register':
-    case 'list':
       console.error(`sharpee ${command}: not yet implemented`);
       return 2;
     default:

--- a/packages/devkit/src/commands/register.ts
+++ b/packages/devkit/src/commands/register.ts
@@ -1,0 +1,38 @@
+/**
+ * register.ts — `sharpee register <location>` and `sharpee list` (ADR-180 Decision 4,
+ * amended: the location-registry verb is `register`).
+ *
+ * Owner context: @sharpee/devkit. Convenience over the `~/.sharpee/devkit` registry so
+ * a story (anywhere) can be referenced by name. Pure orchestration over registry.ts.
+ *
+ * Public interface: runRegister(args), runList().
+ */
+import { registerStory, listStories, registryPath } from '../registry';
+
+/** `sharpee register <location> [--name <n>]` — upsert a name→path mapping. */
+export function runRegister(args: string[]): void {
+  let location: string | undefined;
+  let name: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--name') name = args[++i];
+    else if (!args[i].startsWith('-') && !location) location = args[i];
+    else throw new Error(`unexpected argument: ${args[i]}`);
+  }
+  if (!location) throw new Error('register requires a <location>');
+  const entry = registerStory(location, name);
+  console.log(`registered '${entry.name}' → ${entry.path}`);
+  console.log(`(${registryPath()})`);
+}
+
+/** `sharpee list` — show registered stories, flagging stale entries. */
+export function runList(): void {
+  const entries = listStories();
+  if (entries.length === 0) {
+    console.log('No registered stories. Use `sharpee register <location>`.');
+    return;
+  }
+  const width = Math.max(...entries.map((e) => e.name.length));
+  for (const e of entries) {
+    console.log(`  ${e.name.padEnd(width)}  ${e.path}${e.stale ? '   [STALE: path missing]' : ''}`);
+  }
+}

--- a/packages/devkit/src/commands/standalone-build.test.ts
+++ b/packages/devkit/src/commands/standalone-build.test.ts
@@ -1,0 +1,70 @@
+/**
+ * standalone-build.test.ts — REAL-PATH gate for the standalone `sharpee build`
+ * (ADR-180 U2). Stands up an out-of-workspace consumer project for the bundled
+ * fixture, installs its `@sharpee` closure from the local `tsf build --npm` staging,
+ * and runs the production CLI (`node dist/cli.js build`) in standalone mode — the
+ * detection (no pnpm-workspace.yaml/packages/core above the temp dir) routes to the
+ * standalone path. Asserts a `.sharpee` bundle is produced. No stubs.
+ *
+ * Gated (DEVKIT_INTEGRATION=1 + local staging present) for speed; executed as the
+ * U2 standalone Integration-Reality gate.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { generateConsumer } from '../consumer-gen';
+import { DEFAULT_STAGING } from './test-npm';
+
+const integration = process.env.DEVKIT_INTEGRATION === '1' && existsSync(DEFAULT_STAGING);
+
+/** Minimal consumer tsconfig (the standalone build runs `npx tsc` against it). */
+const TSCONFIG = {
+  compilerOptions: {
+    target: 'ES2022',
+    module: 'CommonJS',
+    moduleResolution: 'node',
+    lib: ['ES2022', 'DOM'],
+    outDir: 'dist',
+    rootDir: 'src',
+    strict: true,
+    esModuleInterop: true,
+    skipLibCheck: true,
+    declaration: false,
+    resolveJsonModule: true,
+  },
+  include: ['src/**/*'],
+  exclude: ['node_modules', 'dist', 'src/browser-entry.ts', 'src/**/*.test.ts'],
+};
+
+describe.skipIf(!integration)('standalone `sharpee build` (real-path)', () => {
+  it('compiles an out-of-repo fixture project and emits a .sharpee bundle', () => {
+    const fixture = join(__dirname, '..', '..', 'fixtures', 'basic-story');
+    const cli = join(__dirname, '..', '..', 'dist', 'cli.js');
+    const tmp = mkdtempSync(join(tmpdir(), 'devkit-standalone-'));
+    try {
+      // Consumer project (@sharpee closure from local staging tarballs).
+      const vendor = join(tmp, 'vendor');
+      mkdirSync(vendor, { recursive: true });
+      generateConsumer({
+        mode: 'local',
+        storyPkgPath: join(fixture, 'package.json'),
+        stagingDir: DEFAULT_STAGING,
+        vendorDir: vendor,
+        outPkgPath: join(tmp, 'package.json'),
+      });
+      cpSync(join(fixture, 'src'), join(tmp, 'src'), { recursive: true });
+      writeFileSync(join(tmp, 'tsconfig.json'), JSON.stringify(TSCONFIG, null, 2));
+      execFileSync('npm', ['install', '--no-fund', '--no-audit'], { cwd: tmp, stdio: 'ignore' });
+
+      // Production CLI, standalone mode (temp dir is not the Sharpee monorepo).
+      execFileSync('node', [cli, 'build'], { cwd: tmp, stdio: 'inherit' });
+
+      const produced = readdirSync(join(tmp, 'dist')).filter((f) => f.endsWith('.sharpee'));
+      expect(produced.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 600_000);
+});

--- a/packages/devkit/src/index.ts
+++ b/packages/devkit/src/index.ts
@@ -18,6 +18,9 @@ export { buildZifmiaServer } from './commands/zifmia';
 export type { ZifmiaBuildOptions } from './commands/zifmia';
 export { runClean } from './commands/clean';
 export type { CleanOptions } from './commands/clean';
+export { runRegister, runList } from './commands/register';
+export { registryPath, readRegistry, registerStory, listStories, lookupStory } from './registry';
+export type { Registry, RegistryEntry } from './registry';
 export { runVerify } from './commands/verify';
 export type { VerifyOptions } from './commands/verify';
 export {

--- a/packages/devkit/src/registry.test.ts
+++ b/packages/devkit/src/registry.test.ts
@@ -1,0 +1,63 @@
+/**
+ * registry.test.ts — the ~/.sharpee/devkit location registry (ADR-180 U3).
+ * Uses SHARPEE_DEVKIT_REGISTRY to point at a temp file (never touches the real one).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerStory, listStories, lookupStory, readRegistry } from './registry';
+
+describe('registry', () => {
+  let home: string;
+  let storyDir: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'devkit-reg-'));
+    process.env.SHARPEE_DEVKIT_REGISTRY = join(home, 'devkit');
+    storyDir = join(home, 'my-game');
+    mkdirSync(storyDir, { recursive: true });
+  });
+  afterEach(() => {
+    delete process.env.SHARPEE_DEVKIT_REGISTRY;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('register upserts a name→path entry (default name = basename) and persists it', () => {
+    const entry = registerStory(storyDir);
+    expect(entry).toEqual({ name: 'my-game', path: storyDir });
+    expect(existsSync(process.env.SHARPEE_DEVKIT_REGISTRY!)).toBe(true);
+    expect(readRegistry().stories['my-game'].path).toBe(storyDir);
+  });
+
+  it('register honors an explicit --name', () => {
+    const entry = registerStory(storyDir, 'zork');
+    expect(entry.name).toBe('zork');
+    expect(lookupStory('zork')).toBe(storyDir);
+  });
+
+  it('register throws when the path does not exist', () => {
+    expect(() => registerStory(join(home, 'nope'))).toThrow(/does not exist/);
+  });
+
+  it('lookupStory returns null for an unregistered name', () => {
+    expect(lookupStory('ghost')).toBeNull();
+  });
+
+  it('lookupStory throws (never silently skips) when a registered path goes missing', () => {
+    registerStory(storyDir, 'gone');
+    rmSync(storyDir, { recursive: true, force: true });
+    expect(() => lookupStory('gone')).toThrow(/missing path/);
+  });
+
+  it('list flags stale entries', () => {
+    registerStory(storyDir, 'live');
+    const removed = join(home, 'removed');
+    mkdirSync(removed);
+    registerStory(removed, 'dead');
+    rmSync(removed, { recursive: true, force: true });
+    const entries = listStories();
+    expect(entries.find((e) => e.name === 'live')!.stale).toBe(false);
+    expect(entries.find((e) => e.name === 'dead')!.stale).toBe(true);
+  });
+});

--- a/packages/devkit/src/registry.ts
+++ b/packages/devkit/src/registry.ts
@@ -1,0 +1,86 @@
+/**
+ * registry.ts — the user-level story location registry at `~/.sharpee/devkit`
+ * (ADR-180 Decision 4, amended: the verb is `register`, not `init`).
+ *
+ * A story is always referable by raw location; this registry is pure convenience —
+ * it maps a name → an absolute path so a story (anywhere, incl. other repos) can be
+ * referenced by name. Machine-level, git-ignored, rebuildable by re-running `register`.
+ *
+ * Format: { "stories": { "<name>": { "path": "<absolute path>" } } }
+ *
+ * Public interface: registryPath, readRegistry, registerStory, listStories, lookupStory.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, resolve } from 'node:path';
+
+export interface Registry {
+  stories: Record<string, { path: string }>;
+}
+
+export interface RegistryEntry {
+  name: string;
+  path: string;
+  /** true if the registered path no longer exists. */
+  stale: boolean;
+}
+
+/** The registry file path (`~/.sharpee/devkit`; overridable via SHARPEE_DEVKIT_REGISTRY). */
+export function registryPath(): string {
+  return process.env.SHARPEE_DEVKIT_REGISTRY || resolve(homedir(), '.sharpee', 'devkit');
+}
+
+/** Read the registry, or an empty one if absent/unparseable. */
+export function readRegistry(): Registry {
+  const p = registryPath();
+  if (!existsSync(p)) return { stories: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(p, 'utf8'));
+    return parsed && typeof parsed === 'object' && parsed.stories ? parsed : { stories: {} };
+  } catch {
+    return { stories: {} };
+  }
+}
+
+function writeRegistry(reg: Registry): void {
+  const p = registryPath();
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(reg, null, 2) + '\n');
+}
+
+/**
+ * Upsert a name→path mapping. Resolves `location` to an absolute path; the default
+ * name is its basename. Returns the stored entry.
+ * @throws if the location does not exist.
+ */
+export function registerStory(location: string, name?: string): { name: string; path: string } {
+  const abs = resolve(location);
+  if (!existsSync(abs)) throw new Error(`cannot register: path does not exist: ${abs}`);
+  const storyName = name || basename(abs);
+  const reg = readRegistry();
+  reg.stories[storyName] = { path: abs };
+  writeRegistry(reg);
+  return { name: storyName, path: abs };
+}
+
+/** All registered stories, each flagged stale if its path no longer exists. */
+export function listStories(): RegistryEntry[] {
+  const reg = readRegistry();
+  return Object.entries(reg.stories)
+    .map(([name, { path }]) => ({ name, path, stale: !existsSync(path) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Resolve a registered name to its absolute path.
+ * @throws if the name is registered but its path no longer exists (stale, never silently skipped).
+ * @returns the path, or null if the name is not registered.
+ */
+export function lookupStory(name: string): string | null {
+  const entry = readRegistry().stories[name];
+  if (!entry) return null;
+  if (!existsSync(entry.path)) {
+    throw new Error(`registered story '${name}' points at a missing path: ${entry.path} (re-run \`sharpee register\`)`);
+  }
+  return entry.path;
+}

--- a/packages/devkit/src/standalone/build-browser.ts
+++ b/packages/devkit/src/standalone/build-browser.ts
@@ -61,14 +61,14 @@ function processTemplate(content: string, info: ProjectInfo): string {
 /**
  * Run the build-browser command
  */
-export async function runBuildBrowserCommand(args: string[]): Promise<void> {
+export async function runBuildBrowserCommand(args: string[], projectDirArg?: string): Promise<void> {
   // Check for help
   if (args.includes('--help') || args.includes('-h')) {
     showHelp();
     return;
   }
 
-  const projectDir = process.cwd();
+  const projectDir = projectDirArg || process.cwd();
   const minify = !args.includes('--no-minify');
   const sourcemap = !args.includes('--no-sourcemap');
 

--- a/packages/devkit/src/standalone/build.ts
+++ b/packages/devkit/src/standalone/build.ts
@@ -52,7 +52,7 @@ function findTranscriptFiles(dir: string, pattern: string): string[] {
   return files.sort();
 }
 
-export async function runBuildCommand(args: string[]): Promise<void> {
+export async function runBuildCommand(args: string[], projectDirArg?: string): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
     showHelp();
     return;
@@ -61,7 +61,8 @@ export async function runBuildCommand(args: string[]): Promise<void> {
   const runTests = args.includes('--test');
   const verbose = args.includes('--verbose') || args.includes('-v');
   const stopOnFailure = args.includes('--stop-on-failure');
-  const projectDir = process.cwd();
+  // Default to cwd (author in their project); a registered story name resolves to its dir.
+  const projectDir = projectDirArg || process.cwd();
   const packagePath = path.join(projectDir, 'package.json');
 
   if (!fs.existsSync(packagePath)) {
@@ -170,7 +171,10 @@ export async function runBuildCommand(args: string[]): Promise<void> {
 
   const browserEntry = path.join(projectDir, 'src', 'browser-entry.ts');
   if (fs.existsSync(browserEntry)) {
-    await runBuildBrowserCommand(args.filter(a => a !== '--help' && a !== '-h' && a !== '--test' && a !== '--verbose' && a !== '-v' && a !== '--stop-on-failure'));
+    await runBuildBrowserCommand(
+      args.filter(a => a !== '--help' && a !== '-h' && a !== '--test' && a !== '--verbose' && a !== '-v' && a !== '--stop-on-failure'),
+      projectDir,
+    );
   } else {
     console.log('  Skipped (no src/browser-entry.ts)\n');
     console.log('  Run "sharpee init-browser" to add browser support.\n');


### PR DESCRIPTION
## What

ADR-180 **Phase U3** — the `~/.sharpee/devkit` location registry (ADR AC-3) — plus the **standalone-build real-path harness** that closes the U2 verification gap. Completes the ADR-180 unify track.

## Standalone real-path gate (closes the U2 gap)

`standalone-build.test.ts` (gated on `DEVKIT_INTEGRATION=1` + local staging) stands up an **out-of-repo** consumer project (its `@sharpee` closure from the local `tsf build --npm` staging) and runs the **production** CLI — `node dist/cli.js build` — in standalone mode (detection routes there since the temp dir isn't the monorepo). Asserts a `.sharpee` bundle is produced.

**Executed: PASS** — compiled the fixture + emitted `dist/*.sharpee` (8.1 KB). The standalone `sharpee build` path is now proven end-to-end, not just dispatch-verified.

## U3 — location registry

- **`registry.ts`** — `~/.sharpee/devkit` (format `{ "stories": { "<name>": { "path": … } } }`; `SHARPEE_DEVKIT_REGISTRY` env override for tests). read / register / list / lookup. A registered path that goes missing **throws on lookup** (never silently skipped) and is flagged `[STALE]` by `list`.
- **`sharpee register <location> [--name]`** + **`sharpee list`** (commands/register.ts), wired into the dispatcher (were "reserved").
- **Registered-name resolution:**
  - standalone `sharpee build <name>` builds at the registered path (the standalone `build`/`build-browser` gained a `projectDir` param; default cwd).
  - `sharpee test:npm <name>` resolves a registered name → path. **Closes ADR AC-3** ("`test <name>` after register").

## Tests

+6 registry unit tests; devkit suite **30 passing, 2 gated-skipped** (the two real-path integration tests run under `DEVKIT_INTEGRATION=1`). Smoked `register`/`list` via the CLI (registry file matches the ADR format).

## Deferred (noted)

- A dedicated `bundle:story` verb — `.sharpee` is already produced by the standalone `build`, so this is a thin convenience extraction for later.
- `sharpee update` (Claude-style self-update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
