### PR TITLE
ADR-189 alignment: drop redundant SceneryTrait adds in book + Family Zoo

### DIFF
--- a/docs/book/parts/part-1/02-your-first-room.md
+++ b/docs/book/parts/part-1/02-your-first-room.md
@@ -170,7 +170,6 @@ initializeWorld(world: WorldModel): void {
     aliases: ['sign', 'wooden sign'],
     article: 'a',
   }));
-  sign.add(new SceneryTrait());
 
   const booth = world.createEntity('ticket booth', EntityType.SCENERY);
   booth.add(new IdentityTrait({
@@ -181,7 +180,6 @@ initializeWorld(world: WorldModel): void {
     aliases: ['booth', 'ticket booth', 'window'],
     article: 'a',
   }));
-  booth.add(new SceneryTrait());
 
   world.moveEntity(sign.id, entrance.id);
   world.moveEntity(booth.id, entrance.id);
@@ -191,9 +189,10 @@ initializeWorld(world: WorldModel): void {
 }
 ```
 
-The ticket booth is built exactly like the sign: an entity, an `IdentityTrait` for
-its name and description, and a `SceneryTrait` so it stays put. Both are placed in
-the entrance, and now `examine booth` in the "Try it" list has something to find.
+The ticket booth is built exactly like the sign: an entity and an `IdentityTrait`
+for its name and description. Both are typed `EntityType.SCENERY`, so they stay
+put, and both are placed in the entrance; now `examine booth` in the "Try it" list
+has something to find.
 
 ## Placing things
 

--- a/docs/book/parts/part-2/04-rooms-and-navigation.md
+++ b/docs/book/parts/part-2/04-rooms-and-navigation.md
@@ -160,8 +160,8 @@ initializeWorld(world: WorldModel): void {
 
   // Step 3: scenery. The welcome sign and ticket booth from Chapter 2 stay
   // in the entrance. The three new rooms get scenery of their own. Each is the
-  // same pattern you already know which includes: an entity, an IdentityTrait,
-  // a SceneryTrait (so it can't be taken), and a moveEntity to place it.
+  // same pattern you already know: an entity, an IdentityTrait, and a moveEntity
+  // to place it. The EntityType.SCENERY type makes each one fixed.
   const sign = world.createEntity('welcome sign', EntityType.SCENERY);
   sign.add(new IdentityTrait({
     name: 'welcome sign',
@@ -169,7 +169,6 @@ initializeWorld(world: WorldModel): void {
     aliases: ['sign', 'welcome sign', 'wooden sign'],
     article: 'a',
   }));
-  sign.add(new SceneryTrait());
   world.moveEntity(sign.id, entrance.id);
 
   const booth = world.createEntity('ticket booth', EntityType.SCENERY);
@@ -181,7 +180,6 @@ initializeWorld(world: WorldModel): void {
     aliases: ['booth', 'ticket booth', 'window'],
     article: 'a',
   }));
-  booth.add(new SceneryTrait());
   world.moveEntity(booth.id, entrance.id);
 
   const directionSigns = world.createEntity('direction signs', EntityType.SCENERY);
@@ -195,7 +193,6 @@ initializeWorld(world: WorldModel): void {
     article: 'some',
     grammaticalNumber: 'plural',
   }));
-  directionSigns.add(new SceneryTrait());
   world.moveEntity(directionSigns.id, mainPath.id);
 
   const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
@@ -208,7 +205,6 @@ initializeWorld(world: WorldModel): void {
     article: 'some',
     grammaticalNumber: 'plural',
   }));
-  goats.add(new SceneryTrait());
   world.moveEntity(goats.id, pettingZoo.id);
 
   const toucan = world.createEntity('toucan', EntityType.SCENERY);
@@ -220,7 +216,6 @@ initializeWorld(world: WorldModel): void {
     aliases: ['toucan', 'bird', 'toco toucan'],
     article: 'a',
   }));
-  toucan.add(new SceneryTrait());
   world.moveEntity(toucan.id, aviary.id);
 
   // Step 4: place the player at the entrance, as in Chapter 2.

--- a/docs/book/parts/part-2/05-scenery-and-portable-objects.md
+++ b/docs/book/parts/part-2/05-scenery-and-portable-objects.md
@@ -33,12 +33,13 @@ That's a complete, takeable object. `EntityType.ITEM` is the type label for a
 generic portable thing; the `IdentityTrait` gives it a name, description, and
 aliases. No trait is needed to make it carryable; that's the default.
 
-## SceneryTrait takes portability away
+## EntityType.SCENERY makes a thing fixed
 
 Most of the things in a room are *not* meant to be carried. You don't want the
 player stuffing a park bench into a backpack or wandering off with the iron
-fence. `SceneryTrait` is how you say "this is part of the world, not a
-collectible." It does exactly one thing: it blocks the taking action.
+fence. Create a fixed thing as `EntityType.SCENERY` and it comes with a
+`SceneryTrait` already attached. That trait does exactly one thing: it blocks the
+taking action.
 
 ```typescript
 const fence = world.createEntity('iron fence', EntityType.SCENERY);
@@ -47,7 +48,6 @@ fence.add(new IdentityTrait({
   description: 'A tall wrought-iron fence with animal silhouettes.',
   aliases: ['fence', 'iron fence', 'railing'],
 }));
-fence.add(new SceneryTrait());
 world.moveEntity(fence.id, entrance.id);
 ```
 
@@ -55,31 +55,31 @@ Now `take fence` gives the player *"iron fence is fixed in place."* But
 `examine fence` still works: scenery blocks *taking*, not *looking*. The entity
 keeps its `IdentityTrait`, so its description is always readable.
 
-> **The mistake everyone makes once:** forgetting `SceneryTrait`. Because items
-> are portable by default, an animal or a wall you created without it can be
-> picked up and carried away. If the player can pocket your waterfall, you left
-> off the scenery trait.
+> **The mistake everyone makes once:** a fixed thing that *isn't* typed
+> `EntityType.SCENERY`. The scenery type pins it for you, but a container, a
+> supporter, or an animal you made an `ACTOR` is portable by default. If the player
+> can pocket your feed dispenser, it has no `SceneryTrait` and you need to add one
+> by hand.
 
-## The label and the trait are two different things
+## When you still add SceneryTrait by hand
 
-This trips people up, because two things share the same word:
+Typing a thing `EntityType.SCENERY` is the usual way to fix it, and it is enough
+on its own. You reach for an explicit `SceneryTrait` in only two cases:
 
-- **`EntityType.SCENERY`** is a *label*. It tells the engine "this entity
-  represents scenery." On its own it does **not** prevent taking.
-- **`SceneryTrait`** is the *mechanism*. It's the thing that actually blocks the
-  taking action.
+- **A fixed thing of another type.** A feed dispenser is a `CONTAINER` and a park
+  bench is a `SUPPORTER`; those types don't arrive fixed, so you add a
+  `SceneryTrait` to pin them in place.
+- **A custom refusal.** A plain `SceneryTrait` gives the standard "fixed in place"
+  line; construct it with your own message to say something specific.
 
-You want both for a proper fixed object. `EntityType.SCENERY` without
-`SceneryTrait` is scenery the player can still pick up — almost never what you
-mean. The pair to keep straight:
-
-| Entity type | Portable by default | Example |
+| Entity type | Fixed by default | Example |
 |---|---|---|
-| `EntityType.ITEM` | Yes | Maps, keys, coins |
-| `EntityType.SCENERY` | No (with `SceneryTrait`) | Fences, benches, animals |
+| `EntityType.ITEM` | No (portable) | Maps, keys, coins |
+| `EntityType.SCENERY` | Yes (gets `SceneryTrait`) | Fences, benches, animals |
+| `EntityType.CONTAINER` / `SUPPORTER` | No (add `SceneryTrait` to fix) | Dispensers, shelves |
 
-A rule of thumb for which to reach for: if you'd find it strange for the player
-to put a thing in their pocket, it's scenery.
+A rule of thumb: if you'd find it strange for the player to put a thing in their
+pocket, make it `EntityType.SCENERY`.
 
 ## Aliases make objects findable
 
@@ -111,7 +111,7 @@ library handles the whole inventory vocabulary without a line of code from you:
 | `drop all` | Drops everything the player is holding |
 
 When the player carries an item and walks to a new room, the item travels with
-them — carried things live inside the player's own container, so they move
+them: carried things live inside the player's own container, so they move
 wherever the player goes. And loose portable objects on the floor are listed
 after the room description:
 
@@ -122,7 +122,7 @@ A wide gravel path winds through the heart of the zoo...
 You can see a souvenir penny here.
 ```
 
-Scenery is *not* listed this way — it's expected to be named in the room's
+Scenery is *not* listed this way; it's expected to be named in the room's
 description prose, where it belongs.
 
 ## How taking actually decides
@@ -138,24 +138,25 @@ types `take map`:
 4. The player sees *"Taken."*
 
 That's the entire rule. Portable or not is simply: *does it have `SceneryTrait`?*
+Creating a thing as `EntityType.SCENERY` is just the quickest way to give it one.
 
 ## Putting it together
 
 Fill each room with scenery for atmosphere, then scatter a few takeable items.
-Scenery gets `SceneryTrait`; items get nothing extra:
+Scenery is typed `EntityType.SCENERY`, which fixes it in place; items get nothing
+extra:
 
 ```typescript
-// Scenery — fixed in place, examinable, mentioned in room prose.
+// Scenery: the SCENERY type fixes it in place, examinable, mentioned in room prose.
 const fence = world.createEntity('iron fence', EntityType.SCENERY);
 fence.add(new IdentityTrait({
   name: 'iron fence',
   description: 'A tall wrought-iron fence with animal silhouettes.',
   aliases: ['fence', 'iron fence', 'railing'],
 }));
-fence.add(new SceneryTrait());
 world.moveEntity(fence.id, entrance.id);
 
-// More scenery — a pair of rabbits in the Petting Zoo, beside the goats.
+// More scenery: a pair of rabbits in the Petting Zoo, beside the goats.
 const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
 rabbits.add(new IdentityTrait({
   name: 'rabbits',
@@ -166,10 +167,9 @@ rabbits.add(new IdentityTrait({
   article: 'some',
   grammaticalNumber: 'plural',
 }));
-rabbits.add(new SceneryTrait());
 world.moveEntity(rabbits.id, pettingZoo.id);
 
-// A takeable item — no SceneryTrait, so it's portable by default.
+// A takeable item: no SceneryTrait, so it's portable by default.
 const zooMap = world.createEntity('zoo map', EntityType.ITEM);
 zooMap.add(new IdentityTrait({
   name: 'zoo map',
@@ -184,7 +184,7 @@ animalFeed.add(new IdentityTrait({
   name: 'bag of animal feed',
   description:
     'A small brown paper bag of dried corn and pellets. The label reads ' +
-    '"ZOO SNACKS — Safe for goats, rabbits, and birds." It rustles invitingly.',
+    '"ZOO SNACKS: Safe for goats, rabbits, and birds." It rustles invitingly.',
   aliases: ['feed', 'animal feed', 'bag of feed', 'bag', 'corn', 'pellets'],
 }));
 world.moveEntity(animalFeed.id, pettingZoo.id);
@@ -216,7 +216,7 @@ penny are portable, the feed waits in the Petting Zoo, and the goats stay put.
 > look                  Map is now on the ground in Main Path
 > east                  Go to the Petting Zoo
 > take feed             Pick up the bag of animal feed
-> take goats            Can't — they're scenery!
+> take goats            Can't: they're scenery!
 ```
 
 ## Key takeaway

--- a/docs/book/parts/part-2/07-openable-locked-doors-and-keys.md
+++ b/docs/book/parts/part-2/07-openable-locked-doors-and-keys.md
@@ -187,7 +187,6 @@ shelves.add(new IdentityTrait({
   description: 'Industrial steel shelving stacked with feed sacks and supplies.',
   aliases: ['shelves', 'metal shelves', 'shelf', 'shelving'],
 }));
-shelves.add(new SceneryTrait());
 world.moveEntity(shelves.id, supplyRoom.id);
 
 // The key: an ordinary item, placed at the entrance for the player to find.

--- a/docs/book/parts/part-2/08-light-and-dark.md
+++ b/docs/book/parts/part-2/08-light-and-dark.md
@@ -170,7 +170,6 @@ sugarGliders.add(new IdentityTrait({
   aliases: ['sugar gliders', 'gliders', 'sugar glider'],
   article: 'some',
 }));
-sugarGliders.add(new SceneryTrait());
 world.moveEntity(sugarGliders.id, nocturnalExhibit.id);
 
 const bushBabies = world.createEntity('bush babies', EntityType.SCENERY);
@@ -180,7 +179,6 @@ bushBabies.add(new IdentityTrait({
   aliases: ['bush babies', 'bush baby', 'galagos'],
   article: 'some',
 }));
-bushBabies.add(new SceneryTrait());
 world.moveEntity(bushBabies.id, nocturnalExhibit.id);
 
 const barnOwl = world.createEntity('barn owl', EntityType.SCENERY);
@@ -190,7 +188,6 @@ barnOwl.add(new IdentityTrait({
   aliases: ['barn owl', 'owl'],
   article: 'a',
 }));
-barnOwl.add(new SceneryTrait());
 world.moveEntity(barnOwl.id, nocturnalExhibit.id);
 ```
 

--- a/docs/book/parts/part-3/12-readable-objects-and-switchable-devices.md
+++ b/docs/book/parts/part-3/12-readable-objects-and-switchable-devices.md
@@ -71,7 +71,6 @@ pettingPlaque.add(new ReadableTrait({
     'temperament. Our pair, Biscuit and Marmalade, were born right ' +
     'here at Willowbrook in 2023.',
 }));
-pettingPlaque.add(new SceneryTrait());
 world.moveEntity(pettingPlaque.id, pettingZoo.id);
 ```
 
@@ -111,8 +110,8 @@ world.moveEntity(brochure.id, entrance.id);
 ```
 
 Readable scenery (plaques, warning signs) and readable items (brochures,
-letters, books) are the same trait; the only difference is whether you also add
-`SceneryTrait`.
+letters, books) are the same trait; the only difference is whether the thing is
+fixed in place.
 
 ## SwitchableTrait — a device with on/off state
 
@@ -185,8 +184,8 @@ match how a person would actually talk about the object.
 ## Key takeaway
 
 `ReadableTrait` separates what an object *says* (`read`) from what it *looks
-like* (`examine`); add `SceneryTrait` for fixed plaques and signs, leave it off
-for portable brochures and books, and use `\n` to shape the text. `SwitchableTrait`
+like* (`examine`); type fixed plaques and signs `EntityType.SCENERY` and leave
+portable brochures and books as plain items, and use `\n` to shape the text. `SwitchableTrait`
 gives any device an on/off toggle through the `switch`/`turn` verbs, alone for a
 plain device like the radio, or paired with another trait when the switch should
 drive something. It's the sibling of `OpenableTrait`: same shape, different verbs,

--- a/tutorials/familyzoo/package.json
+++ b/tutorials/familyzoo/package.json
@@ -19,19 +19,19 @@
     "clean": "sharpee clean"
   },
   "dependencies": {
-    "@sharpee/core": "^1.0.8",
-    "@sharpee/engine": "^1.0.8",
-    "@sharpee/event-processor": "^1.0.8",
-    "@sharpee/helpers": "^1.0.8",
-    "@sharpee/if-domain": "^1.0.8",
-    "@sharpee/lang-en-us": "^1.0.8",
-    "@sharpee/media": "^1.0.8",
-    "@sharpee/parser-en-us": "^1.0.8",
+    "@sharpee/core": "^1.1.1",
+    "@sharpee/engine": "^1.1.1",
+    "@sharpee/event-processor": "^1.1.1",
+    "@sharpee/helpers": "^1.1.1",
+    "@sharpee/if-domain": "^1.1.1",
+    "@sharpee/lang-en-us": "^1.2.0",
+    "@sharpee/media": "^1.1.1",
+    "@sharpee/parser-en-us": "^1.1.1",
     "@sharpee/platform-browser": "^1.1.2",
-    "@sharpee/plugin-npc": "^1.0.8",
-    "@sharpee/plugin-scheduler": "^1.0.8",
-    "@sharpee/stdlib": "^1.0.8",
-    "@sharpee/world-model": "^1.0.8"
+    "@sharpee/plugin-npc": "^1.1.1",
+    "@sharpee/plugin-scheduler": "^1.1.1",
+    "@sharpee/stdlib": "^1.2.0",
+    "@sharpee/world-model": "^1.2.0"
   },
   "devDependencies": {
     "@sharpee/devkit": "^1.1.4",

--- a/tutorials/familyzoo/pnpm-lock.yaml
+++ b/tutorials/familyzoo/pnpm-lock.yaml
@@ -9,44 +9,44 @@ importers:
   .:
     dependencies:
       '@sharpee/core':
-        specifier: ^1.0.8
+        specifier: ^1.1.1
         version: 1.1.1
       '@sharpee/engine':
-        specifier: ^1.0.8
+        specifier: ^1.1.1
         version: 1.1.1
       '@sharpee/event-processor':
-        specifier: ^1.0.8
+        specifier: ^1.1.1
         version: 1.1.1
       '@sharpee/helpers':
-        specifier: ^1.0.8
+        specifier: ^1.1.1
         version: 1.1.1
       '@sharpee/if-domain':
-        specifier: ^1.0.8
+        specifier: ^1.1.1
         version: 1.1.1
       '@sharpee/lang-en-us':
-        specifier: ^1.0.8
-        version: 1.1.1
+        specifier: ^1.2.0
+        version: 1.2.0
       '@sharpee/media':
-        specifier: ^1.0.8
+        specifier: ^1.1.1
         version: 1.1.1
       '@sharpee/parser-en-us':
-        specifier: ^1.0.8
+        specifier: ^1.1.1
         version: 1.1.1
       '@sharpee/platform-browser':
         specifier: ^1.1.2
-        version: 1.1.2(@sharpee/channel-service@1.1.1)(@sharpee/core@1.1.1)(@sharpee/engine@1.1.1)(@sharpee/if-domain@1.1.1)(@sharpee/stdlib@1.1.1)(@sharpee/text-blocks@1.1.1)(@sharpee/world-model@1.1.1)
+        version: 1.1.2(@sharpee/channel-service@1.1.1)(@sharpee/core@1.1.1)(@sharpee/engine@1.1.1)(@sharpee/if-domain@1.1.1)(@sharpee/stdlib@1.2.0)(@sharpee/text-blocks@1.1.1)(@sharpee/world-model@1.2.0)
       '@sharpee/plugin-npc':
-        specifier: ^1.0.8
+        specifier: ^1.1.1
         version: 1.1.1
       '@sharpee/plugin-scheduler':
-        specifier: ^1.0.8
+        specifier: ^1.1.1
         version: 1.1.1
       '@sharpee/stdlib':
-        specifier: ^1.0.8
-        version: 1.1.1
+        specifier: ^1.2.0
+        version: 1.2.0
       '@sharpee/world-model':
-        specifier: ^1.0.8
-        version: 1.1.1
+        specifier: ^1.2.0
+        version: 1.2.0
     devDependencies:
       '@sharpee/devkit':
         specifier: ^1.1.4
@@ -110,8 +110,11 @@ packages:
   '@sharpee/if-services@1.1.1':
     resolution: {integrity: sha512-/UYHCfBB4KOb2cbouMq+FZeX0NVchCbAuos1GdVvC7nebIM9LRzDCgVkKB3jw9YzNfrZAZpfSu6nL7YQilaWZg==}
 
-  '@sharpee/lang-en-us@1.1.1':
-    resolution: {integrity: sha512-gZFsE2iqkJWEA/aneb4clVqcVLHg4f17Gwgv5n0xYlNNq3jgYxPwwRf8FE4m4T6tw+RwAAmQphzc3Jufsumzog==}
+  '@sharpee/if-services@1.1.2':
+    resolution: {integrity: sha512-42LJ5AjGnrVltJSg4BdOqiE3nIXDP5YYImC/X4Uz71ojOrBm5sB5lO8NpJdW9gO96t4xFX1ugDsvOg975JOt4Q==}
+
+  '@sharpee/lang-en-us@1.2.0':
+    resolution: {integrity: sha512-De3PNbwE7dlZoNcRsrmdyKMitenIzeSiWvC8OBnyOr7X7xODryEufB6kwNCuatObMPE9wxl7JJhv1Chs+HjDRg==}
     engines: {node: '>=18.0.0'}
 
   '@sharpee/media@1.1.1':
@@ -145,8 +148,8 @@ packages:
     resolution: {integrity: sha512-ve8V72SAIyg00hj+S/q2uCu0B6Y7nd35aXWm5PbcnUkC0f5UoeRC3yg4fSZB7t9GXlQL3kXdE+f0T6uY1YPecg==}
     engines: {node: '>=18.0.0'}
 
-  '@sharpee/stdlib@1.1.1':
-    resolution: {integrity: sha512-4qTJiEkI5nXEhDK1uo7pCUBqQSIPAErJPUJV6EkGRAsPSfMvA6u7vuV3o0NEBJClh1S+MlgBmhRfzUDw+nhuAg==}
+  '@sharpee/stdlib@1.2.0':
+    resolution: {integrity: sha512-pWOhqBdQodJmY9hLWhA2+OtW/9K+i9l+xnnIwRIJoxbwTbFqoO7mKYfTEhd+wYNDzvHDWO+jBPldzo3XdigRdA==}
     engines: {node: '>=18.0.0'}
 
   '@sharpee/text-blocks@1.1.1':
@@ -157,8 +160,8 @@ packages:
     resolution: {integrity: sha512-hRJHvHkHuVRchsASFlAjiELeBfHvbkr8VwykYXBwy+8gdAPRQng67eS135zNGbroWL750KML1aCAypVi1GMRqA==}
     hasBin: true
 
-  '@sharpee/world-model@1.1.1':
-    resolution: {integrity: sha512-7DuB7XjlFUK09CRh1r2HOB6Wm5nmm/Q8ZaH+GDR50/1R/Q//5HwbBmYYKZbvxWET/Wj9Nku3Dy2YIr64R0ktDg==}
+  '@sharpee/world-model@1.2.0':
+    resolution: {integrity: sha512-GmNlwF6vuYNxCj/NT4Gk1m3aAwXkYpwjzULqpAfXc0DY84fY7EFWnLNCOHE34QCdZfiuxmAjnahrYybP7hRdOQ==}
     engines: {node: '>=18.0.0'}
 
   '@types/node@20.19.43':
@@ -340,17 +343,17 @@ snapshots:
       '@sharpee/ext-testing': 1.1.1
       '@sharpee/ide-protocol': 1.1.1
       '@sharpee/if-domain': 1.1.1
-      '@sharpee/lang-en-us': 1.1.1
+      '@sharpee/lang-en-us': 1.2.0
       '@sharpee/parser-en-us': 1.1.1
-      '@sharpee/stdlib': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/stdlib': 1.2.0
+      '@sharpee/world-model': 1.2.0
 
   '@sharpee/channel-service@1.1.1':
     dependencies:
       '@sharpee/core': 1.1.1
       '@sharpee/if-domain': 1.1.1
       '@sharpee/text-blocks': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/world-model': 1.2.0
 
   '@sharpee/core@1.1.1':
     dependencies:
@@ -370,29 +373,29 @@ snapshots:
       '@sharpee/event-processor': 1.1.1
       '@sharpee/if-domain': 1.1.1
       '@sharpee/if-services': 1.1.1
-      '@sharpee/lang-en-us': 1.1.1
+      '@sharpee/lang-en-us': 1.2.0
       '@sharpee/parser-en-us': 1.1.1
       '@sharpee/plugins': 1.1.1
-      '@sharpee/stdlib': 1.1.1
+      '@sharpee/stdlib': 1.2.0
       '@sharpee/text-blocks': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/world-model': 1.2.0
       fflate: 0.8.3
 
   '@sharpee/event-processor@1.1.1':
     dependencies:
       '@sharpee/core': 1.1.1
       '@sharpee/if-domain': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/world-model': 1.2.0
 
   '@sharpee/ext-testing@1.1.1':
     dependencies:
       '@sharpee/core': 1.1.1
       '@sharpee/if-domain': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/world-model': 1.2.0
 
   '@sharpee/helpers@1.1.1':
     dependencies:
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/world-model': 1.2.0
 
   '@sharpee/ide-protocol@1.1.1': {}
 
@@ -405,9 +408,15 @@ snapshots:
     dependencies:
       '@sharpee/core': 1.1.1
       '@sharpee/if-domain': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/world-model': 1.2.0
 
-  '@sharpee/lang-en-us@1.1.1':
+  '@sharpee/if-services@1.1.2':
+    dependencies:
+      '@sharpee/core': 1.1.1
+      '@sharpee/if-domain': 1.1.1
+      '@sharpee/world-model': 1.2.0
+
+  '@sharpee/lang-en-us@1.2.0':
     dependencies:
       '@sharpee/core': 1.1.1
       '@sharpee/if-domain': 1.1.1
@@ -420,46 +429,46 @@ snapshots:
     dependencies:
       '@sharpee/core': 1.1.1
       '@sharpee/if-domain': 1.1.1
-      '@sharpee/lang-en-us': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/lang-en-us': 1.2.0
+      '@sharpee/world-model': 1.2.0
 
-  '@sharpee/platform-browser@1.1.2(@sharpee/channel-service@1.1.1)(@sharpee/core@1.1.1)(@sharpee/engine@1.1.1)(@sharpee/if-domain@1.1.1)(@sharpee/stdlib@1.1.1)(@sharpee/text-blocks@1.1.1)(@sharpee/world-model@1.1.1)':
+  '@sharpee/platform-browser@1.1.2(@sharpee/channel-service@1.1.1)(@sharpee/core@1.1.1)(@sharpee/engine@1.1.1)(@sharpee/if-domain@1.1.1)(@sharpee/stdlib@1.2.0)(@sharpee/text-blocks@1.1.1)(@sharpee/world-model@1.2.0)':
     dependencies:
       '@sharpee/channel-service': 1.1.1
       '@sharpee/core': 1.1.1
       '@sharpee/engine': 1.1.1
       '@sharpee/if-domain': 1.1.1
-      '@sharpee/stdlib': 1.1.1
+      '@sharpee/stdlib': 1.2.0
       '@sharpee/text-blocks': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/world-model': 1.2.0
       lz-string: 1.5.0
 
   '@sharpee/plugin-npc@1.1.1':
     dependencies:
       '@sharpee/core': 1.1.1
       '@sharpee/plugins': 1.1.1
-      '@sharpee/stdlib': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/stdlib': 1.2.0
+      '@sharpee/world-model': 1.2.0
 
   '@sharpee/plugin-scheduler@1.1.1':
     dependencies:
       '@sharpee/core': 1.1.1
       '@sharpee/plugins': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/world-model': 1.2.0
 
   '@sharpee/plugins@1.1.1':
     dependencies:
       '@sharpee/core': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/world-model': 1.2.0
 
-  '@sharpee/stdlib@1.1.1':
+  '@sharpee/stdlib@1.2.0':
     dependencies:
       '@sharpee/core': 1.1.1
       '@sharpee/if-domain': 1.1.1
-      '@sharpee/if-services': 1.1.1
-      '@sharpee/lang-en-us': 1.1.1
+      '@sharpee/if-services': 1.1.2
+      '@sharpee/lang-en-us': 1.2.0
       '@sharpee/text-blocks': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/world-model': 1.2.0
 
   '@sharpee/text-blocks@1.1.1': {}
 
@@ -469,14 +478,14 @@ snapshots:
       '@sharpee/channel-service': 1.1.1
       '@sharpee/core': 1.1.1
       '@sharpee/engine': 1.1.1
-      '@sharpee/lang-en-us': 1.1.1
+      '@sharpee/lang-en-us': 1.2.0
       '@sharpee/parser-en-us': 1.1.1
-      '@sharpee/stdlib': 1.1.1
-      '@sharpee/world-model': 1.1.1
+      '@sharpee/stdlib': 1.2.0
+      '@sharpee/world-model': 1.2.0
       chalk: 4.1.2
       glob: 10.5.0
 
-  '@sharpee/world-model@1.1.1':
+  '@sharpee/world-model@1.2.0':
     dependencies:
       '@sharpee/core': 1.1.1
       '@sharpee/if-domain': 1.1.1

--- a/tutorials/familyzoo/src/ch02-first-room.ts
+++ b/tutorials/familyzoo/src/ch02-first-room.ts
@@ -71,7 +71,6 @@ class FamilyZooStory implements Story {
       aliases: ['sign', 'wooden sign'],
       article: 'a',
     }));
-    sign.add(new SceneryTrait());
 
     const booth = world.createEntity('ticket booth', EntityType.SCENERY);
     booth.add(new IdentityTrait({
@@ -82,7 +81,6 @@ class FamilyZooStory implements Story {
       aliases: ['booth', 'ticket booth', 'window'],
       article: 'a',
     }));
-    booth.add(new SceneryTrait());
 
     world.moveEntity(sign.id, entrance.id);
     world.moveEntity(booth.id, entrance.id);

--- a/tutorials/familyzoo/src/ch04-navigation.ts
+++ b/tutorials/familyzoo/src/ch04-navigation.ts
@@ -211,7 +211,6 @@ class FamilyZooStory implements Story {
       properName: false,
       article: 'a',
     }));
-    sign.add(new SceneryTrait());
     world.moveEntity(sign.id, entrance.id);
 
     // --- Ticket Booth (Zoo Entrance) ---
@@ -226,7 +225,6 @@ class FamilyZooStory implements Story {
       properName: false,
       article: 'a',
     }));
-    booth.add(new SceneryTrait());
     world.moveEntity(booth.id, entrance.id);
 
     // --- Direction Signs (Main Path) ---
@@ -241,7 +239,6 @@ class FamilyZooStory implements Story {
       properName: false,
       article: 'some',
     }));
-    directionSigns.add(new SceneryTrait());
     world.moveEntity(directionSigns.id, mainPath.id);
 
     // --- Goats (Petting Zoo) ---
@@ -257,7 +254,6 @@ class FamilyZooStory implements Story {
       properName: false,
       article: 'some',
     }));
-    goats.add(new SceneryTrait());
     world.moveEntity(goats.id, pettingZoo.id);
 
     // --- Toucan (Aviary) ---
@@ -272,7 +268,6 @@ class FamilyZooStory implements Story {
       properName: false,
       article: 'a',
     }));
-    toucan.add(new SceneryTrait());
     world.moveEntity(toucan.id, aviary.id);
 
 

--- a/tutorials/familyzoo/src/ch05-scenery-items.ts
+++ b/tutorials/familyzoo/src/ch05-scenery-items.ts
@@ -192,7 +192,6 @@ class FamilyZooStory implements Story {
       aliases: ['sign', 'welcome sign', 'wooden sign'],
       properName: false, article: 'a',
     }));
-    sign.add(new SceneryTrait());
     world.moveEntity(sign.id, entrance.id);
 
     const booth = world.createEntity('ticket booth', EntityType.SCENERY);
@@ -204,7 +203,6 @@ class FamilyZooStory implements Story {
       aliases: ['booth', 'ticket booth'],
       properName: false, article: 'a',
     }));
-    booth.add(new SceneryTrait());
     world.moveEntity(booth.id, entrance.id);
 
     const fence = world.createEntity('iron fence', EntityType.SCENERY);
@@ -216,7 +214,6 @@ class FamilyZooStory implements Story {
       aliases: ['fence', 'iron fence', 'railing'],
       properName: false, article: 'an',
     }));
-    fence.add(new SceneryTrait());
     world.moveEntity(fence.id, entrance.id);
 
     // Main Path scenery
@@ -229,7 +226,6 @@ class FamilyZooStory implements Story {
       aliases: ['signs', 'direction signs', 'arrow signs', 'post'],
       properName: false, article: 'some',
     }));
-    directionSigns.add(new SceneryTrait());
     world.moveEntity(directionSigns.id, mainPath.id);
 
     const benches = world.createEntity('wooden benches', EntityType.SCENERY);
@@ -241,7 +237,6 @@ class FamilyZooStory implements Story {
       aliases: ['benches', 'bench', 'wooden benches', 'seat'],
       properName: false, article: 'some',
     }));
-    benches.add(new SceneryTrait());
     world.moveEntity(benches.id, mainPath.id);
 
     const flowerBeds = world.createEntity('flower beds', EntityType.SCENERY);
@@ -253,7 +248,6 @@ class FamilyZooStory implements Story {
       aliases: ['flowers', 'flower beds', 'marigolds', 'petunias'],
       properName: false, article: 'some',
     }));
-    flowerBeds.add(new SceneryTrait());
     world.moveEntity(flowerBeds.id, mainPath.id);
 
     // Petting Zoo scenery
@@ -267,7 +261,6 @@ class FamilyZooStory implements Story {
       aliases: ['goats', 'pygmy goats', 'goat'],
       properName: false, article: 'some',
     }));
-    goats.add(new SceneryTrait());
     world.moveEntity(goats.id, pettingZoo.id);
 
     const hayBale = world.createEntity('hay bale', EntityType.SCENERY);
@@ -279,7 +272,6 @@ class FamilyZooStory implements Story {
       aliases: ['hay', 'hay bale', 'bale', 'straw'],
       properName: false, article: 'a',
     }));
-    hayBale.add(new SceneryTrait());
     world.moveEntity(hayBale.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
@@ -291,7 +283,6 @@ class FamilyZooStory implements Story {
       aliases: ['rabbits', 'rabbit', 'bunnies', 'bunny'],
       properName: false, article: 'some',
     }));
-    rabbits.add(new SceneryTrait());
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     // Aviary scenery
@@ -303,7 +294,6 @@ class FamilyZooStory implements Story {
       aliases: ['toucan', 'toco toucan'],
       properName: false, article: 'a',
     }));
-    toucan.add(new SceneryTrait());
     world.moveEntity(toucan.id, aviary.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
@@ -314,7 +304,6 @@ class FamilyZooStory implements Story {
       aliases: ['parrots', 'parrot', 'macaws', 'macaw', 'birds'],
       properName: false, article: 'some',
     }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     const waterfall = world.createEntity('waterfall', EntityType.SCENERY);
@@ -326,7 +315,6 @@ class FamilyZooStory implements Story {
       aliases: ['waterfall', 'water', 'basin', 'fountain'],
       properName: false, article: 'a',
     }));
-    waterfall.add(new SceneryTrait());
     world.moveEntity(waterfall.id, aviary.id);
 
 

--- a/tutorials/familyzoo/src/ch06-containers.ts
+++ b/tutorials/familyzoo/src/ch06-containers.ts
@@ -187,65 +187,53 @@ class FamilyZooStory implements Story {
     // Zoo Entrance scenery
     const sign = world.createEntity('welcome sign', EntityType.SCENERY);
     sign.add(new IdentityTrait({ name: 'welcome sign', description: 'A brightly painted wooden sign reads: "WELCOME TO WILLOWBROOK FAMILY ZOO."', aliases: ['sign', 'welcome sign'], properName: false, article: 'a' }));
-    sign.add(new SceneryTrait());
     world.moveEntity(sign.id, entrance.id);
 
     const booth = world.createEntity('ticket booth', EntityType.SCENERY);
     booth.add(new IdentityTrait({ name: 'ticket booth', description: 'A small wooden booth with a "Self-Guided Tours" sign.', aliases: ['booth', 'ticket booth'], properName: false, article: 'a' }));
-    booth.add(new SceneryTrait());
     world.moveEntity(booth.id, entrance.id);
 
     const ironFence = world.createEntity('iron fence', EntityType.SCENERY);
     ironFence.add(new IdentityTrait({ name: 'iron fence', description: 'A tall wrought-iron fence with animal silhouettes.', aliases: ['fence', 'iron fence', 'railing'], properName: false, article: 'an' }));
-    ironFence.add(new SceneryTrait());
     world.moveEntity(ironFence.id, entrance.id);
 
     // Main Path scenery
     const directionSigns = world.createEntity('direction signs', EntityType.SCENERY);
     directionSigns.add(new IdentityTrait({ name: 'direction signs', grammaticalNumber: 'plural', description: 'Arrow signs: PETTING ZOO (east), AVIARY (west), EXIT (north).', aliases: ['signs', 'direction signs', 'arrow signs'], properName: false, article: 'some' }));
-    directionSigns.add(new SceneryTrait());
     world.moveEntity(directionSigns.id, mainPath.id);
 
     const flowerBeds = world.createEntity('flower beds', EntityType.SCENERY);
     flowerBeds.add(new IdentityTrait({ name: 'flower beds', grammaticalNumber: 'plural', description: 'Tidy beds of marigolds and petunias.', aliases: ['flowers', 'flower beds'], properName: false, article: 'some' }));
-    flowerBeds.add(new SceneryTrait());
     world.moveEntity(flowerBeds.id, mainPath.id);
 
     // Petting Zoo scenery
     const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
     goats.add(new IdentityTrait({ name: 'pygmy goats', grammaticalNumber: 'plural', description: 'Three pygmy goats hoping you have food.', aliases: ['goats', 'pygmy goats', 'goat'], properName: false, article: 'some' }));
-    goats.add(new SceneryTrait());
     world.moveEntity(goats.id, pettingZoo.id);
 
     const hayBale = world.createEntity('hay bale', EntityType.SCENERY);
     hayBale.add(new IdentityTrait({ name: 'hay bale', description: 'A large round bale of golden hay.', aliases: ['hay', 'hay bale', 'bale'], properName: false, article: 'a' }));
-    hayBale.add(new SceneryTrait());
     world.moveEntity(hayBale.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
     rabbits.add(new IdentityTrait({ name: 'rabbits', grammaticalNumber: 'plural', description: 'A pair of Holland Lop rabbits with floppy ears.', aliases: ['rabbits', 'rabbit', 'bunnies'], properName: false, article: 'some' }));
-    rabbits.add(new SceneryTrait());
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     // Aviary scenery
     const toucan = world.createEntity('toucan', EntityType.SCENERY);
     toucan.add(new IdentityTrait({ name: 'toucan', description: 'A Toco toucan with an enormous orange-and-black bill.', aliases: ['toucan', 'toco toucan'], properName: false, article: 'a' }));
-    toucan.add(new SceneryTrait());
     world.moveEntity(toucan.id, aviary.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
     parrots.add(new IdentityTrait({ name: 'parrots', grammaticalNumber: 'plural', description: 'A raucous flock of scarlet macaws and grey African parrots.', aliases: ['parrots', 'parrot', 'macaws', 'birds'], properName: false, article: 'some' }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     const waterfall = world.createEntity('waterfall', EntityType.SCENERY);
     waterfall.add(new IdentityTrait({ name: 'waterfall', description: 'A gentle artificial waterfall cascading into a stone basin.', aliases: ['waterfall', 'water', 'basin'], properName: false, article: 'a' }));
-    waterfall.add(new SceneryTrait());
     world.moveEntity(waterfall.id, aviary.id);
 
     const perches = world.createEntity('rope perches', EntityType.SCENERY);
     perches.add(new IdentityTrait({ name: 'rope perches', grammaticalNumber: 'plural', description: 'Thick sisal ropes strung between wooden posts — both furniture and snacks for the parrots.', aliases: ['perches', 'rope perches', 'ropes', 'rope'], properName: false, article: 'some' }));
-    perches.add(new SceneryTrait());
     world.moveEntity(perches.id, aviary.id);
 
 

--- a/tutorials/familyzoo/src/ch07-doors-keys.ts
+++ b/tutorials/familyzoo/src/ch07-doors-keys.ts
@@ -241,62 +241,50 @@ class FamilyZooStory implements Story {
 
     const sign = world.createEntity('welcome sign', EntityType.SCENERY);
     sign.add(new IdentityTrait({ name: 'welcome sign', description: 'A brightly painted wooden sign reads: "WELCOME TO WILLOWBROOK FAMILY ZOO."', aliases: ['sign', 'welcome sign'], properName: false, article: 'a' }));
-    sign.add(new SceneryTrait());
     world.moveEntity(sign.id, entrance.id);
 
     const booth = world.createEntity('ticket booth', EntityType.SCENERY);
     booth.add(new IdentityTrait({ name: 'ticket booth', description: 'A small wooden booth with a "Self-Guided Tours" sign.', aliases: ['booth', 'ticket booth'], properName: false, article: 'a' }));
-    booth.add(new SceneryTrait());
     world.moveEntity(booth.id, entrance.id);
 
     const ironFence = world.createEntity('iron fence', EntityType.SCENERY);
     ironFence.add(new IdentityTrait({ name: 'iron fence', description: 'A tall wrought-iron fence with animal silhouettes.', aliases: ['fence', 'iron fence', 'railing'], properName: false, article: 'an' }));
-    ironFence.add(new SceneryTrait());
     world.moveEntity(ironFence.id, entrance.id);
 
     const directionSigns = world.createEntity('direction signs', EntityType.SCENERY);
     directionSigns.add(new IdentityTrait({ name: 'direction signs', grammaticalNumber: 'plural', description: 'Arrow signs: PETTING ZOO (east), AVIARY (west), EXIT (north).', aliases: ['signs', 'direction signs', 'arrow signs'], properName: false, article: 'some' }));
-    directionSigns.add(new SceneryTrait());
     world.moveEntity(directionSigns.id, mainPath.id);
 
     const flowerBeds = world.createEntity('flower beds', EntityType.SCENERY);
     flowerBeds.add(new IdentityTrait({ name: 'flower beds', grammaticalNumber: 'plural', description: 'Tidy beds of marigolds and petunias.', aliases: ['flowers', 'flower beds'], properName: false, article: 'some' }));
-    flowerBeds.add(new SceneryTrait());
     world.moveEntity(flowerBeds.id, mainPath.id);
 
     const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
     goats.add(new IdentityTrait({ name: 'pygmy goats', grammaticalNumber: 'plural', description: 'Three pygmy goats hoping you have food.', aliases: ['goats', 'pygmy goats', 'goat'], properName: false, article: 'some' }));
-    goats.add(new SceneryTrait());
     world.moveEntity(goats.id, pettingZoo.id);
 
     const hayBale = world.createEntity('hay bale', EntityType.SCENERY);
     hayBale.add(new IdentityTrait({ name: 'hay bale', description: 'A large round bale of golden hay.', aliases: ['hay', 'hay bale', 'bale'], properName: false, article: 'a' }));
-    hayBale.add(new SceneryTrait());
     world.moveEntity(hayBale.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
     rabbits.add(new IdentityTrait({ name: 'rabbits', grammaticalNumber: 'plural', description: 'A pair of Holland Lop rabbits with floppy ears.', aliases: ['rabbits', 'rabbit', 'bunnies'], properName: false, article: 'some' }));
-    rabbits.add(new SceneryTrait());
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     const toucan = world.createEntity('toucan', EntityType.SCENERY);
     toucan.add(new IdentityTrait({ name: 'toucan', description: 'A Toco toucan with an enormous orange-and-black bill.', aliases: ['toucan', 'toco toucan'], properName: false, article: 'a' }));
-    toucan.add(new SceneryTrait());
     world.moveEntity(toucan.id, aviary.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
     parrots.add(new IdentityTrait({ name: 'parrots', grammaticalNumber: 'plural', description: 'A raucous flock of scarlet macaws and grey African parrots.', aliases: ['parrots', 'parrot', 'macaws', 'birds'], properName: false, article: 'some' }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     const waterfall = world.createEntity('waterfall', EntityType.SCENERY);
     waterfall.add(new IdentityTrait({ name: 'waterfall', description: 'A gentle artificial waterfall cascading into a stone basin.', aliases: ['waterfall', 'water', 'basin'], properName: false, article: 'a' }));
-    waterfall.add(new SceneryTrait());
     world.moveEntity(waterfall.id, aviary.id);
 
     const perches = world.createEntity('rope perches', EntityType.SCENERY);
     perches.add(new IdentityTrait({ name: 'rope perches', grammaticalNumber: 'plural', description: 'Thick sisal ropes strung between wooden posts — both furniture and snacks for the parrots.', aliases: ['perches', 'rope perches', 'ropes', 'rope'], properName: false, article: 'some' }));
-    perches.add(new SceneryTrait());
     world.moveEntity(perches.id, aviary.id);
 
     // Supply Room scenery
@@ -311,7 +299,6 @@ class FamilyZooStory implements Story {
       properName: false,
       article: 'some',
     }));
-    shelves.add(new SceneryTrait());
     world.moveEntity(shelves.id, supplyRoom.id);
 
     const corkBoard = world.createEntity('cork board', EntityType.SCENERY);
@@ -326,7 +313,6 @@ class FamilyZooStory implements Story {
       properName: false,
       article: 'a',
     }));
-    corkBoard.add(new SceneryTrait());
     world.moveEntity(corkBoard.id, supplyRoom.id);
 
 

--- a/tutorials/familyzoo/src/ch08-light-dark.ts
+++ b/tutorials/familyzoo/src/ch08-light-dark.ts
@@ -188,72 +188,58 @@ class FamilyZooStory implements Story {
 
     const sign = world.createEntity('welcome sign', EntityType.SCENERY);
     sign.add(new IdentityTrait({ name: 'welcome sign', description: 'A brightly painted wooden sign reads: "WELCOME TO WILLOWBROOK FAMILY ZOO."', aliases: ['sign', 'welcome sign'], properName: false, article: 'a' }));
-    sign.add(new SceneryTrait());
     world.moveEntity(sign.id, entrance.id);
 
     const booth = world.createEntity('ticket booth', EntityType.SCENERY);
     booth.add(new IdentityTrait({ name: 'ticket booth', description: 'A small wooden booth with a "Self-Guided Tours" sign.', aliases: ['booth', 'ticket booth'], properName: false, article: 'a' }));
-    booth.add(new SceneryTrait());
     world.moveEntity(booth.id, entrance.id);
 
     const ironFence = world.createEntity('iron fence', EntityType.SCENERY);
     ironFence.add(new IdentityTrait({ name: 'iron fence', description: 'A tall wrought-iron fence with animal silhouettes.', aliases: ['fence', 'iron fence', 'railing'], properName: false, article: 'an' }));
-    ironFence.add(new SceneryTrait());
     world.moveEntity(ironFence.id, entrance.id);
 
     const directionSigns = world.createEntity('direction signs', EntityType.SCENERY);
     directionSigns.add(new IdentityTrait({ name: 'direction signs', grammaticalNumber: 'plural', description: 'Arrow signs: PETTING ZOO (east), AVIARY (west), EXIT (north).', aliases: ['signs', 'direction signs', 'arrow signs'], properName: false, article: 'some' }));
-    directionSigns.add(new SceneryTrait());
     world.moveEntity(directionSigns.id, mainPath.id);
 
     const flowerBeds = world.createEntity('flower beds', EntityType.SCENERY);
     flowerBeds.add(new IdentityTrait({ name: 'flower beds', grammaticalNumber: 'plural', description: 'Tidy beds of marigolds and petunias.', aliases: ['flowers', 'flower beds'], properName: false, article: 'some' }));
-    flowerBeds.add(new SceneryTrait());
     world.moveEntity(flowerBeds.id, mainPath.id);
 
     const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
     goats.add(new IdentityTrait({ name: 'pygmy goats', grammaticalNumber: 'plural', description: 'Three pygmy goats hoping you have food.', aliases: ['goats', 'pygmy goats', 'goat'], properName: false, article: 'some' }));
-    goats.add(new SceneryTrait());
     world.moveEntity(goats.id, pettingZoo.id);
 
     const hayBale = world.createEntity('hay bale', EntityType.SCENERY);
     hayBale.add(new IdentityTrait({ name: 'hay bale', description: 'A large round bale of golden hay.', aliases: ['hay', 'hay bale', 'bale'], properName: false, article: 'a' }));
-    hayBale.add(new SceneryTrait());
     world.moveEntity(hayBale.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
     rabbits.add(new IdentityTrait({ name: 'rabbits', grammaticalNumber: 'plural', description: 'A pair of Holland Lop rabbits with floppy ears.', aliases: ['rabbits', 'rabbit', 'bunnies'], properName: false, article: 'some' }));
-    rabbits.add(new SceneryTrait());
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     const toucan = world.createEntity('toucan', EntityType.SCENERY);
     toucan.add(new IdentityTrait({ name: 'toucan', description: 'A Toco toucan with an enormous orange-and-black bill.', aliases: ['toucan', 'toco toucan'], properName: false, article: 'a' }));
-    toucan.add(new SceneryTrait());
     world.moveEntity(toucan.id, aviary.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
     parrots.add(new IdentityTrait({ name: 'parrots', grammaticalNumber: 'plural', description: 'A raucous flock of scarlet macaws and grey African parrots.', aliases: ['parrots', 'parrot', 'macaws', 'birds'], properName: false, article: 'some' }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     const waterfall = world.createEntity('waterfall', EntityType.SCENERY);
     waterfall.add(new IdentityTrait({ name: 'waterfall', description: 'A gentle artificial waterfall cascading into a stone basin.', aliases: ['waterfall', 'water', 'basin'], properName: false, article: 'a' }));
-    waterfall.add(new SceneryTrait());
     world.moveEntity(waterfall.id, aviary.id);
 
     const perches = world.createEntity('rope perches', EntityType.SCENERY);
     perches.add(new IdentityTrait({ name: 'rope perches', grammaticalNumber: 'plural', description: 'Thick sisal ropes strung between wooden posts — both furniture and snacks for the parrots.', aliases: ['perches', 'rope perches', 'ropes', 'rope'], properName: false, article: 'some' }));
-    perches.add(new SceneryTrait());
     world.moveEntity(perches.id, aviary.id);
 
     const shelves = world.createEntity('metal shelves', EntityType.SCENERY);
     shelves.add(new IdentityTrait({ name: 'metal shelves', grammaticalNumber: 'plural', description: 'Industrial metal shelving units stacked with supplies.', aliases: ['shelves', 'metal shelves', 'shelf'], properName: false, article: 'some' }));
-    shelves.add(new SceneryTrait());
     world.moveEntity(shelves.id, supplyRoom.id);
 
     const corkBoard = world.createEntity('cork board', EntityType.SCENERY);
     corkBoard.add(new IdentityTrait({ name: 'cork board', description: 'A cork board with staff schedules. A note in red marker: "DON\'T FORGET: nocturnal exhibit lights need new batteries!"', aliases: ['cork board', 'board', 'notices'], properName: false, article: 'a' }));
-    corkBoard.add(new SceneryTrait());
     world.moveEntity(corkBoard.id, supplyRoom.id);
 
     // Nocturnal exhibit scenery (only visible when the room is lit)
@@ -268,7 +254,6 @@ class FamilyZooStory implements Story {
       properName: false,
       article: 'some',
     }));
-    sugarGliders.add(new SceneryTrait());
     world.moveEntity(sugarGliders.id, nocturnalExhibit.id);
 
     const bushBabies = world.createEntity('bush babies', EntityType.SCENERY);
@@ -282,7 +267,6 @@ class FamilyZooStory implements Story {
       properName: false,
       article: 'some',
     }));
-    bushBabies.add(new SceneryTrait());
     world.moveEntity(bushBabies.id, nocturnalExhibit.id);
 
     const barnOwl = world.createEntity('barn owl', EntityType.SCENERY);
@@ -296,7 +280,6 @@ class FamilyZooStory implements Story {
       properName: false,
       article: 'a',
     }));
-    barnOwl.add(new SceneryTrait());
     world.moveEntity(barnOwl.id, nocturnalExhibit.id);
 
 

--- a/tutorials/familyzoo/src/ch12-readables.ts
+++ b/tutorials/familyzoo/src/ch12-readables.ts
@@ -145,87 +145,70 @@ class FamilyZooStory implements Story {
 
     const sign = world.createEntity('welcome sign', EntityType.SCENERY);
     sign.add(new IdentityTrait({ name: 'welcome sign', description: 'A brightly painted wooden sign reads: "WELCOME TO WILLOWBROOK FAMILY ZOO."', aliases: ['sign', 'welcome sign'], properName: false, article: 'a' }));
-    sign.add(new SceneryTrait());
     world.moveEntity(sign.id, entrance.id);
 
     const booth = world.createEntity('ticket booth', EntityType.SCENERY);
     booth.add(new IdentityTrait({ name: 'ticket booth', description: 'A small wooden booth with a "Self-Guided Tours" sign.', aliases: ['booth', 'ticket booth'], properName: false, article: 'a' }));
-    booth.add(new SceneryTrait());
     world.moveEntity(booth.id, entrance.id);
 
     const ironFence = world.createEntity('iron fence', EntityType.SCENERY);
     ironFence.add(new IdentityTrait({ name: 'iron fence', description: 'A tall wrought-iron fence with animal silhouettes.', aliases: ['fence', 'iron fence', 'railing'], properName: false, article: 'an' }));
-    ironFence.add(new SceneryTrait());
     world.moveEntity(ironFence.id, entrance.id);
 
     const directionSigns = world.createEntity('direction signs', EntityType.SCENERY);
     directionSigns.add(new IdentityTrait({ name: 'direction signs', grammaticalNumber: 'plural', description: 'Arrow signs: PETTING ZOO (east), AVIARY (west), EXIT (north).', aliases: ['signs', 'direction signs', 'arrow signs'], properName: false, article: 'some' }));
-    directionSigns.add(new SceneryTrait());
     world.moveEntity(directionSigns.id, mainPath.id);
 
     const flowerBeds = world.createEntity('flower beds', EntityType.SCENERY);
     flowerBeds.add(new IdentityTrait({ name: 'flower beds', grammaticalNumber: 'plural', description: 'Tidy beds of marigolds and petunias.', aliases: ['flowers', 'flower beds'], properName: false, article: 'some' }));
-    flowerBeds.add(new SceneryTrait());
     world.moveEntity(flowerBeds.id, mainPath.id);
 
     const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
     goats.add(new IdentityTrait({ name: 'pygmy goats', grammaticalNumber: 'plural', description: 'Three pygmy goats hoping you have food.', aliases: ['goats', 'pygmy goats', 'goat'], properName: false, article: 'some' }));
-    goats.add(new SceneryTrait());
     world.moveEntity(goats.id, pettingZoo.id);
 
     const hayBale = world.createEntity('hay bale', EntityType.SCENERY);
     hayBale.add(new IdentityTrait({ name: 'hay bale', description: 'A large round bale of golden hay.', aliases: ['hay', 'hay bale', 'bale'], properName: false, article: 'a' }));
-    hayBale.add(new SceneryTrait());
     world.moveEntity(hayBale.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
     rabbits.add(new IdentityTrait({ name: 'rabbits', grammaticalNumber: 'plural', description: 'A pair of Holland Lop rabbits with floppy ears.', aliases: ['rabbits', 'rabbit', 'bunnies'], properName: false, article: 'some' }));
-    rabbits.add(new SceneryTrait());
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     const toucan = world.createEntity('toucan', EntityType.SCENERY);
     toucan.add(new IdentityTrait({ name: 'toucan', description: 'A Toco toucan with an enormous orange-and-black bill.', aliases: ['toucan', 'toco toucan'], properName: false, article: 'a' }));
-    toucan.add(new SceneryTrait());
     world.moveEntity(toucan.id, aviary.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
     parrots.add(new IdentityTrait({ name: 'parrots', grammaticalNumber: 'plural', description: 'A raucous flock of scarlet macaws and grey African parrots.', aliases: ['parrots', 'parrot', 'macaws', 'birds'], properName: false, article: 'some' }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     const waterfall = world.createEntity('waterfall', EntityType.SCENERY);
     waterfall.add(new IdentityTrait({ name: 'waterfall', description: 'A gentle artificial waterfall cascading into a stone basin.', aliases: ['waterfall', 'water', 'basin'], properName: false, article: 'a' }));
-    waterfall.add(new SceneryTrait());
     world.moveEntity(waterfall.id, aviary.id);
 
     const perches = world.createEntity('rope perches', EntityType.SCENERY);
     perches.add(new IdentityTrait({ name: 'rope perches', grammaticalNumber: 'plural', description: 'Thick sisal ropes strung between wooden posts — both furniture and snacks for the parrots.', aliases: ['perches', 'rope perches', 'ropes', 'rope'], properName: false, article: 'some' }));
-    perches.add(new SceneryTrait());
     world.moveEntity(perches.id, aviary.id);
 
     const shelves = world.createEntity('metal shelves', EntityType.SCENERY);
     shelves.add(new IdentityTrait({ name: 'metal shelves', grammaticalNumber: 'plural', description: 'Industrial metal shelving units stacked with supplies.', aliases: ['shelves', 'metal shelves', 'shelf'], properName: false, article: 'some' }));
-    shelves.add(new SceneryTrait());
     world.moveEntity(shelves.id, supplyRoom.id);
 
     const corkBoard = world.createEntity('cork board', EntityType.SCENERY);
     corkBoard.add(new IdentityTrait({ name: 'cork board', description: 'A cork board with staff schedules. A note in red marker: "DON\'T FORGET: nocturnal exhibit lights need new batteries!"', aliases: ['cork board', 'board', 'notices'], properName: false, article: 'a' }));
-    corkBoard.add(new SceneryTrait());
     world.moveEntity(corkBoard.id, supplyRoom.id);
 
     const sugarGliders = world.createEntity('sugar gliders', EntityType.SCENERY);
     sugarGliders.add(new IdentityTrait({ name: 'sugar gliders', grammaticalNumber: 'plural', description: 'A family of tiny sugar gliders with enormous dark eyes, leaping between branches.', aliases: ['sugar gliders', 'gliders'], properName: false, article: 'some' }));
-    sugarGliders.add(new SceneryTrait());
     world.moveEntity(sugarGliders.id, nocturnalExhibit.id);
 
     const bushBabies = world.createEntity('bush babies', EntityType.SCENERY);
     bushBabies.add(new IdentityTrait({ name: 'bush babies', grammaticalNumber: 'plural', description: 'Two bush babies with impossibly large round eyes, clinging to a rope with tiny hands.', aliases: ['bush babies', 'galagos'], properName: false, article: 'some' }));
-    bushBabies.add(new SceneryTrait());
     world.moveEntity(bushBabies.id, nocturnalExhibit.id);
 
     const barnOwl = world.createEntity('barn owl', EntityType.SCENERY);
     barnOwl.add(new IdentityTrait({ name: 'barn owl', description: 'An enormous barn owl with a heart-shaped white face on a fake tree stump.', aliases: ['barn owl', 'owl'], properName: false, article: 'a' }));
-    barnOwl.add(new SceneryTrait());
     world.moveEntity(barnOwl.id, nocturnalExhibit.id);
 
 
@@ -236,19 +219,16 @@ class FamilyZooStory implements Story {
     const pettingPlaque = world.createEntity('info plaque', EntityType.SCENERY);
     pettingPlaque.add(new IdentityTrait({ name: 'info plaque', description: 'A brass plaque mounted on a wooden post near the petting zoo gate.', aliases: ['plaque', 'info plaque', 'brass plaque'], properName: false, article: 'an' }));
     pettingPlaque.add(new ReadableTrait({ text: 'PYGMY GOATS — These Nigerian Dwarf goats are gentle, curious, and always hungry.\n\nHOLLAND LOP RABBITS — Known for their floppy ears. Our pair, Biscuit and Marmalade, were born here in 2023.' }));
-    pettingPlaque.add(new SceneryTrait());
     world.moveEntity(pettingPlaque.id, pettingZoo.id);
 
     const aviaryPlaque = world.createEntity('aviary plaque', EntityType.SCENERY);
     aviaryPlaque.add(new IdentityTrait({ name: 'aviary plaque', description: 'A colorful information board near the aviary entrance.', aliases: ['plaque', 'aviary plaque', 'information board'], properName: false, article: 'an' }));
     aviaryPlaque.add(new ReadableTrait({ text: 'WELCOME TO THE AVIARY — Home to over 30 species!\n\nTOCO TOUCAN — Its bill weighs less than a smartphone.\n\nSCARLET MACAW — Can live over 75 years. Our oldest, Captain, is 42.' }));
-    aviaryPlaque.add(new SceneryTrait());
     world.moveEntity(aviaryPlaque.id, aviary.id);
 
     const warningSign = world.createEntity('warning sign', EntityType.SCENERY);
     warningSign.add(new IdentityTrait({ name: 'warning sign', description: 'A yellow warning sign near the nocturnal exhibit entrance.', aliases: ['warning', 'warning sign', 'yellow sign'], properName: false, article: 'a' }));
     warningSign.add(new ReadableTrait({ text: 'CAUTION: The Nocturnal Animals Exhibit is kept dark. Please use a flashlight. Do NOT use camera flash. (We don\'t talk about the Great Owl Incident of 2022.)' }));
-    warningSign.add(new SceneryTrait());
     world.moveEntity(warningSign.id, supplyRoom.id);
 
     const brochure = world.createEntity('zoo brochure', EntityType.ITEM);

--- a/tutorials/familyzoo/src/ch13-event-handlers.ts
+++ b/tutorials/familyzoo/src/ch13-event-handlers.ts
@@ -221,99 +221,80 @@ class FamilyZooStory implements Story {
 
     const sign = world.createEntity('welcome sign', EntityType.SCENERY);
     sign.add(new IdentityTrait({ name: 'welcome sign', description: 'A brightly painted wooden sign reads: "WELCOME TO WILLOWBROOK FAMILY ZOO."', aliases: ['sign', 'welcome sign'], properName: false, article: 'a' }));
-    sign.add(new SceneryTrait());
     world.moveEntity(sign.id, entrance.id);
 
     const booth = world.createEntity('ticket booth', EntityType.SCENERY);
     booth.add(new IdentityTrait({ name: 'ticket booth', description: 'A small wooden booth with a "Self-Guided Tours" sign.', aliases: ['booth', 'ticket booth'], properName: false, article: 'a' }));
-    booth.add(new SceneryTrait());
     world.moveEntity(booth.id, entrance.id);
 
     const ironFence = world.createEntity('iron fence', EntityType.SCENERY);
     ironFence.add(new IdentityTrait({ name: 'iron fence', description: 'A tall wrought-iron fence with animal silhouettes.', aliases: ['fence', 'iron fence', 'railing'], properName: false, article: 'an' }));
-    ironFence.add(new SceneryTrait());
     world.moveEntity(ironFence.id, entrance.id);
 
     const directionSigns = world.createEntity('direction signs', EntityType.SCENERY);
     directionSigns.add(new IdentityTrait({ name: 'direction signs', grammaticalNumber: 'plural', description: 'Arrow signs: PETTING ZOO (east), AVIARY (west), EXIT (north).', aliases: ['signs', 'direction signs', 'arrow signs'], properName: false, article: 'some' }));
-    directionSigns.add(new SceneryTrait());
     world.moveEntity(directionSigns.id, mainPath.id);
 
     const flowerBeds = world.createEntity('flower beds', EntityType.SCENERY);
     flowerBeds.add(new IdentityTrait({ name: 'flower beds', grammaticalNumber: 'plural', description: 'Tidy beds of marigolds and petunias.', aliases: ['flowers', 'flower beds'], properName: false, article: 'some' }));
-    flowerBeds.add(new SceneryTrait());
     world.moveEntity(flowerBeds.id, mainPath.id);
 
     const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
     goats.add(new IdentityTrait({ name: 'pygmy goats', grammaticalNumber: 'plural', description: 'Three pygmy goats hoping you have food.', aliases: ['goats', 'pygmy goats', 'goat'], properName: false, article: 'some' }));
-    goats.add(new SceneryTrait());
     world.moveEntity(goats.id, pettingZoo.id);
 
     const hayBale = world.createEntity('hay bale', EntityType.SCENERY);
     hayBale.add(new IdentityTrait({ name: 'hay bale', description: 'A large round bale of golden hay.', aliases: ['hay', 'hay bale', 'bale'], properName: false, article: 'a' }));
-    hayBale.add(new SceneryTrait());
     world.moveEntity(hayBale.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
     rabbits.add(new IdentityTrait({ name: 'rabbits', grammaticalNumber: 'plural', description: 'A pair of Holland Lop rabbits with floppy ears.', aliases: ['rabbits', 'rabbit', 'bunnies'], properName: false, article: 'some' }));
-    rabbits.add(new SceneryTrait());
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     const toucan = world.createEntity('toucan', EntityType.SCENERY);
     toucan.add(new IdentityTrait({ name: 'toucan', description: 'A Toco toucan with an enormous orange-and-black bill.', aliases: ['toucan', 'toco toucan'], properName: false, article: 'a' }));
-    toucan.add(new SceneryTrait());
     world.moveEntity(toucan.id, aviary.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
     parrots.add(new IdentityTrait({ name: 'parrots', grammaticalNumber: 'plural', description: 'A raucous flock of scarlet macaws and grey African parrots.', aliases: ['parrots', 'macaws', 'birds'], properName: false, article: 'some' }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     const waterfall = world.createEntity('waterfall', EntityType.SCENERY);
     waterfall.add(new IdentityTrait({ name: 'waterfall', description: 'A gentle artificial waterfall cascading into a stone basin.', aliases: ['waterfall', 'water', 'basin'], properName: false, article: 'a' }));
-    waterfall.add(new SceneryTrait());
     world.moveEntity(waterfall.id, aviary.id);
 
     const perches = world.createEntity('rope perches', EntityType.SCENERY);
     perches.add(new IdentityTrait({ name: 'rope perches', grammaticalNumber: 'plural', description: 'Thick sisal ropes strung between wooden posts — both furniture and snacks for the parrots.', aliases: ['perches', 'rope perches', 'ropes', 'rope'], properName: false, article: 'some' }));
-    perches.add(new SceneryTrait());
     world.moveEntity(perches.id, aviary.id);
 
     const shelves = world.createEntity('metal shelves', EntityType.SCENERY);
     shelves.add(new IdentityTrait({ name: 'metal shelves', grammaticalNumber: 'plural', description: 'Industrial metal shelving units stacked with supplies.', aliases: ['shelves', 'metal shelves', 'shelf'], properName: false, article: 'some' }));
-    shelves.add(new SceneryTrait());
     world.moveEntity(shelves.id, supplyRoom.id);
 
     const corkBoard = world.createEntity('cork board', EntityType.SCENERY);
     corkBoard.add(new IdentityTrait({ name: 'cork board', description: 'A cork board with staff schedules. A note in red marker: "DON\'T FORGET: nocturnal exhibit lights need new batteries!"', aliases: ['cork board', 'board', 'notices'], properName: false, article: 'a' }));
-    corkBoard.add(new SceneryTrait());
     world.moveEntity(corkBoard.id, supplyRoom.id);
 
     const sugarGliders = world.createEntity('sugar gliders', EntityType.SCENERY);
     sugarGliders.add(new IdentityTrait({ name: 'sugar gliders', grammaticalNumber: 'plural', description: 'A family of tiny sugar gliders with enormous dark eyes, leaping between branches.', aliases: ['sugar gliders', 'gliders'], properName: false, article: 'some' }));
-    sugarGliders.add(new SceneryTrait());
     world.moveEntity(sugarGliders.id, nocturnalExhibit.id);
 
     const bushBabies = world.createEntity('bush babies', EntityType.SCENERY);
     bushBabies.add(new IdentityTrait({ name: 'bush babies', grammaticalNumber: 'plural', description: 'Two bush babies with impossibly large round eyes, clinging to a rope with tiny hands.', aliases: ['bush babies', 'galagos'], properName: false, article: 'some' }));
-    bushBabies.add(new SceneryTrait());
     world.moveEntity(bushBabies.id, nocturnalExhibit.id);
 
     const barnOwl = world.createEntity('barn owl', EntityType.SCENERY);
     barnOwl.add(new IdentityTrait({ name: 'barn owl', description: 'An enormous barn owl with a heart-shaped white face on a fake tree stump.', aliases: ['barn owl', 'owl'], properName: false, article: 'a' }));
-    barnOwl.add(new SceneryTrait());
     world.moveEntity(barnOwl.id, nocturnalExhibit.id);
 
     // --- Gift Shop scenery ---
 
     const stuffedAnimals = world.createEntity('stuffed animals', EntityType.SCENERY);
     stuffedAnimals.add(new IdentityTrait({ name: 'stuffed animals', grammaticalNumber: 'plural', description: 'Shelves of plush tigers, pandas, and penguins in various sizes.', aliases: ['stuffed animals', 'plush', 'toys'], properName: false, article: 'some' }));
-    stuffedAnimals.add(new SceneryTrait());
     world.moveEntity(stuffedAnimals.id, giftShop.id);
 
     const postcards = world.createEntity('postcards', EntityType.SCENERY);
     postcards.add(new IdentityTrait({ name: 'postcards', grammaticalNumber: 'plural', description: 'A spinning rack of postcards showing the zoo\'s greatest hits.', aliases: ['postcards', 'cards', 'postcard rack'], properName: false, article: 'some' }));
-    postcards.add(new SceneryTrait());
     world.moveEntity(postcards.id, giftShop.id);
 
 
@@ -324,19 +305,16 @@ class FamilyZooStory implements Story {
     const pettingPlaque = world.createEntity('info plaque', EntityType.SCENERY);
     pettingPlaque.add(new IdentityTrait({ name: 'info plaque', description: 'A brass plaque mounted on a wooden post near the petting zoo gate.', aliases: ['plaque', 'info plaque', 'brass plaque'], properName: false, article: 'an' }));
     pettingPlaque.add(new ReadableTrait({ text: 'PYGMY GOATS — These Nigerian Dwarf goats are gentle, curious, and always hungry.\n\nHOLLAND LOP RABBITS — Known for their floppy ears. Our pair, Biscuit and Marmalade, were born here in 2023.' }));
-    pettingPlaque.add(new SceneryTrait());
     world.moveEntity(pettingPlaque.id, pettingZoo.id);
 
     const aviaryPlaque = world.createEntity('aviary plaque', EntityType.SCENERY);
     aviaryPlaque.add(new IdentityTrait({ name: 'aviary plaque', description: 'A colorful information board near the aviary entrance.', aliases: ['plaque', 'aviary plaque', 'information board'], properName: false, article: 'an' }));
     aviaryPlaque.add(new ReadableTrait({ text: 'WELCOME TO THE AVIARY — Home to over 30 species!\n\nTOCO TOUCAN — Its bill weighs less than a smartphone.\n\nSCARLET MACAW — Can live over 75 years. Our oldest, Captain, is 42.' }));
-    aviaryPlaque.add(new SceneryTrait());
     world.moveEntity(aviaryPlaque.id, aviary.id);
 
     const warningSign = world.createEntity('warning sign', EntityType.SCENERY);
     warningSign.add(new IdentityTrait({ name: 'warning sign', description: 'A yellow warning sign near the nocturnal exhibit entrance.', aliases: ['warning', 'warning sign', 'yellow sign'], properName: false, article: 'a' }));
     warningSign.add(new ReadableTrait({ text: 'CAUTION: The Nocturnal Animals Exhibit is kept dark. Please use a flashlight. Do NOT use camera flash. (We don\'t talk about the Great Owl Incident of 2022.)' }));
-    warningSign.add(new SceneryTrait());
     world.moveEntity(warningSign.id, supplyRoom.id);
 
     const brochure = world.createEntity('zoo brochure', EntityType.ITEM);

--- a/tutorials/familyzoo/src/ch14-custom-actions.ts
+++ b/tutorials/familyzoo/src/ch14-custom-actions.ts
@@ -381,97 +381,78 @@ class FamilyZooStory implements Story {
 
     const sign = world.createEntity('welcome sign', EntityType.SCENERY);
     sign.add(new IdentityTrait({ name: 'welcome sign', description: 'A brightly painted wooden sign reads: "WELCOME TO WILLOWBROOK FAMILY ZOO."', aliases: ['sign', 'welcome sign'], properName: false, article: 'a' }));
-    sign.add(new SceneryTrait());
     world.moveEntity(sign.id, entrance.id);
 
     const booth = world.createEntity('ticket booth', EntityType.SCENERY);
     booth.add(new IdentityTrait({ name: 'ticket booth', description: 'A small wooden booth with a "Self-Guided Tours" sign.', aliases: ['booth', 'ticket booth'], properName: false, article: 'a' }));
-    booth.add(new SceneryTrait());
     world.moveEntity(booth.id, entrance.id);
 
     const ironFence = world.createEntity('iron fence', EntityType.SCENERY);
     ironFence.add(new IdentityTrait({ name: 'iron fence', description: 'A tall wrought-iron fence with animal silhouettes.', aliases: ['fence', 'iron fence', 'railing'], properName: false, article: 'an' }));
-    ironFence.add(new SceneryTrait());
     world.moveEntity(ironFence.id, entrance.id);
 
     const directionSigns = world.createEntity('direction signs', EntityType.SCENERY);
     directionSigns.add(new IdentityTrait({ name: 'direction signs', grammaticalNumber: 'plural', description: 'Arrow signs: PETTING ZOO (east), AVIARY (west), EXIT (north).', aliases: ['signs', 'direction signs', 'arrow signs'], properName: false, article: 'some' }));
-    directionSigns.add(new SceneryTrait());
     world.moveEntity(directionSigns.id, mainPath.id);
 
     const flowerBeds = world.createEntity('flower beds', EntityType.SCENERY);
     flowerBeds.add(new IdentityTrait({ name: 'flower beds', grammaticalNumber: 'plural', description: 'Tidy beds of marigolds and petunias.', aliases: ['flowers', 'flower beds'], properName: false, article: 'some' }));
-    flowerBeds.add(new SceneryTrait());
     world.moveEntity(flowerBeds.id, mainPath.id);
 
     const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
     goats.add(new IdentityTrait({ name: 'pygmy goats', grammaticalNumber: 'plural', description: 'Three pygmy goats hoping you have food.', aliases: ['goats', 'pygmy goats', 'goat'], properName: false, article: 'some' }));
-    goats.add(new SceneryTrait());
     world.moveEntity(goats.id, pettingZoo.id);
 
     const hayBale = world.createEntity('hay bale', EntityType.SCENERY);
     hayBale.add(new IdentityTrait({ name: 'hay bale', description: 'A large round bale of golden hay.', aliases: ['hay', 'hay bale', 'bale'], properName: false, article: 'a' }));
-    hayBale.add(new SceneryTrait());
     world.moveEntity(hayBale.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
     rabbits.add(new IdentityTrait({ name: 'rabbits', grammaticalNumber: 'plural', description: 'A pair of Holland Lop rabbits with floppy ears.', aliases: ['rabbits', 'rabbit', 'bunnies'], properName: false, article: 'some' }));
-    rabbits.add(new SceneryTrait());
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     const toucan = world.createEntity('toucan', EntityType.SCENERY);
     toucan.add(new IdentityTrait({ name: 'toucan', description: 'A Toco toucan with an enormous orange-and-black bill.', aliases: ['toucan', 'toco toucan'], properName: false, article: 'a' }));
-    toucan.add(new SceneryTrait());
     world.moveEntity(toucan.id, aviary.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
     parrots.add(new IdentityTrait({ name: 'parrots', grammaticalNumber: 'plural', description: 'A raucous flock of scarlet macaws and grey African parrots.', aliases: ['parrots', 'macaws', 'birds'], properName: false, article: 'some' }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     const waterfall = world.createEntity('waterfall', EntityType.SCENERY);
     waterfall.add(new IdentityTrait({ name: 'waterfall', description: 'A gentle artificial waterfall cascading into a stone basin.', aliases: ['waterfall', 'water', 'basin'], properName: false, article: 'a' }));
-    waterfall.add(new SceneryTrait());
     world.moveEntity(waterfall.id, aviary.id);
 
     const perches = world.createEntity('rope perches', EntityType.SCENERY);
     perches.add(new IdentityTrait({ name: 'rope perches', grammaticalNumber: 'plural', description: 'Thick sisal ropes strung between wooden posts — both furniture and snacks for the parrots.', aliases: ['perches', 'rope perches', 'ropes', 'rope'], properName: false, article: 'some' }));
-    perches.add(new SceneryTrait());
     world.moveEntity(perches.id, aviary.id);
 
     const shelves = world.createEntity('metal shelves', EntityType.SCENERY);
     shelves.add(new IdentityTrait({ name: 'metal shelves', grammaticalNumber: 'plural', description: 'Industrial metal shelving units stacked with supplies.', aliases: ['shelves', 'metal shelves', 'shelf'], properName: false, article: 'some' }));
-    shelves.add(new SceneryTrait());
     world.moveEntity(shelves.id, supplyRoom.id);
 
     const corkBoard = world.createEntity('cork board', EntityType.SCENERY);
     corkBoard.add(new IdentityTrait({ name: 'cork board', description: 'A cork board with staff schedules. A note in red marker: "DON\'T FORGET: nocturnal exhibit lights need new batteries!"', aliases: ['cork board', 'board', 'notices'], properName: false, article: 'a' }));
-    corkBoard.add(new SceneryTrait());
     world.moveEntity(corkBoard.id, supplyRoom.id);
 
     const sugarGliders = world.createEntity('sugar gliders', EntityType.SCENERY);
     sugarGliders.add(new IdentityTrait({ name: 'sugar gliders', grammaticalNumber: 'plural', description: 'A family of tiny sugar gliders with enormous dark eyes, leaping between branches.', aliases: ['sugar gliders', 'gliders'], properName: false, article: 'some' }));
-    sugarGliders.add(new SceneryTrait());
     world.moveEntity(sugarGliders.id, nocturnalExhibit.id);
 
     const bushBabies = world.createEntity('bush babies', EntityType.SCENERY);
     bushBabies.add(new IdentityTrait({ name: 'bush babies', grammaticalNumber: 'plural', description: 'Two bush babies with impossibly large round eyes, clinging to a rope with tiny hands.', aliases: ['bush babies', 'galagos'], properName: false, article: 'some' }));
-    bushBabies.add(new SceneryTrait());
     world.moveEntity(bushBabies.id, nocturnalExhibit.id);
 
     const barnOwl = world.createEntity('barn owl', EntityType.SCENERY);
     barnOwl.add(new IdentityTrait({ name: 'barn owl', description: 'An enormous barn owl with a heart-shaped white face on a fake tree stump.', aliases: ['barn owl', 'owl'], properName: false, article: 'a' }));
-    barnOwl.add(new SceneryTrait());
     world.moveEntity(barnOwl.id, nocturnalExhibit.id);
 
     const stuffedAnimals = world.createEntity('stuffed animals', EntityType.SCENERY);
     stuffedAnimals.add(new IdentityTrait({ name: 'stuffed animals', grammaticalNumber: 'plural', description: 'Shelves of plush tigers, pandas, and penguins in various sizes.', aliases: ['stuffed animals', 'plush', 'toys'], properName: false, article: 'some' }));
-    stuffedAnimals.add(new SceneryTrait());
     world.moveEntity(stuffedAnimals.id, giftShop.id);
 
     const postcards = world.createEntity('postcards', EntityType.SCENERY);
     postcards.add(new IdentityTrait({ name: 'postcards', grammaticalNumber: 'plural', description: 'A spinning rack of postcards showing the zoo\'s greatest hits.', aliases: ['postcards', 'cards', 'postcard rack'], properName: false, article: 'some' }));
-    postcards.add(new SceneryTrait());
     world.moveEntity(postcards.id, giftShop.id);
 
     // ========================================================================
@@ -481,19 +462,16 @@ class FamilyZooStory implements Story {
     const pettingPlaque = world.createEntity('info plaque', EntityType.SCENERY);
     pettingPlaque.add(new IdentityTrait({ name: 'info plaque', description: 'A brass plaque mounted on a wooden post near the petting zoo gate.', aliases: ['plaque', 'info plaque', 'brass plaque'], properName: false, article: 'an' }));
     pettingPlaque.add(new ReadableTrait({ text: 'PYGMY GOATS — These Nigerian Dwarf goats are gentle, curious, and always hungry.\n\nHOLLAND LOP RABBITS — Known for their floppy ears. Our pair, Biscuit and Marmalade, were born here in 2023.' }));
-    pettingPlaque.add(new SceneryTrait());
     world.moveEntity(pettingPlaque.id, pettingZoo.id);
 
     const aviaryPlaque = world.createEntity('aviary plaque', EntityType.SCENERY);
     aviaryPlaque.add(new IdentityTrait({ name: 'aviary plaque', description: 'A colorful information board near the aviary entrance.', aliases: ['plaque', 'aviary plaque', 'information board'], properName: false, article: 'an' }));
     aviaryPlaque.add(new ReadableTrait({ text: 'WELCOME TO THE AVIARY — Home to over 30 species!\n\nTOCO TOUCAN — Its bill weighs less than a smartphone.\n\nSCARLET MACAW — Can live over 75 years. Our oldest, Captain, is 42.' }));
-    aviaryPlaque.add(new SceneryTrait());
     world.moveEntity(aviaryPlaque.id, aviary.id);
 
     const warningSign = world.createEntity('warning sign', EntityType.SCENERY);
     warningSign.add(new IdentityTrait({ name: 'warning sign', description: 'A yellow warning sign near the nocturnal exhibit entrance.', aliases: ['warning', 'warning sign', 'yellow sign'], properName: false, article: 'a' }));
     warningSign.add(new ReadableTrait({ text: 'CAUTION: The Nocturnal Animals Exhibit is kept dark. Please use a flashlight. Do NOT use camera flash. (We don\'t talk about the Great Owl Incident of 2022.)' }));
-    warningSign.add(new SceneryTrait());
     world.moveEntity(warningSign.id, supplyRoom.id);
 
     const brochure = world.createEntity('zoo brochure', EntityType.ITEM);

--- a/tutorials/familyzoo/src/ch15-capability-dispatch.ts
+++ b/tutorials/familyzoo/src/ch15-capability-dispatch.ts
@@ -466,14 +466,12 @@ class FamilyZooStory implements Story {
     ] as [string, string, string[], IFEntity][]) {
       const e = world.createEntity(name, EntityType.SCENERY);
       e.add(new IdentityTrait({ name, description: desc, aliases, properName: false, article: 'a' }));
-      e.add(new SceneryTrait());
       world.moveEntity(e.id, room.id);
     }
 
     // Additional scenery with special traits (readable, switchable)
     const corkBoard = world.createEntity('cork board', EntityType.SCENERY);
     corkBoard.add(new IdentityTrait({ name: 'cork board', description: 'A cork board with staff schedules. A note in red marker: "DON\'T FORGET: nocturnal exhibit lights need new batteries!"', aliases: ['cork board', 'board', 'notices'], properName: false, article: 'a' }));
-    corkBoard.add(new SceneryTrait());
     world.moveEntity(corkBoard.id, supplyRoom.id);
 
     const radio = world.createEntity('radio', EntityType.ITEM);
@@ -485,19 +483,16 @@ class FamilyZooStory implements Story {
     const pettingPlaque = world.createEntity('info plaque', EntityType.SCENERY);
     pettingPlaque.add(new IdentityTrait({ name: 'info plaque', description: 'A brass plaque mounted on a wooden post near the petting zoo gate.', aliases: ['plaque', 'info plaque', 'brass plaque'], properName: false, article: 'an' }));
     pettingPlaque.add(new ReadableTrait({ text: 'PYGMY GOATS — These Nigerian Dwarf goats are gentle, curious, and always hungry.\n\nHOLLAND LOP RABBITS — Known for their floppy ears. Our pair, Biscuit and Marmalade, were born here in 2023.' }));
-    pettingPlaque.add(new SceneryTrait());
     world.moveEntity(pettingPlaque.id, pettingZoo.id);
 
     const aviaryPlaque = world.createEntity('aviary plaque', EntityType.SCENERY);
     aviaryPlaque.add(new IdentityTrait({ name: 'aviary plaque', description: 'A colorful information board near the aviary entrance.', aliases: ['plaque', 'aviary plaque', 'information board'], properName: false, article: 'an' }));
     aviaryPlaque.add(new ReadableTrait({ text: 'WELCOME TO THE AVIARY — Home to over 30 species!\n\nTOCO TOUCAN — Its bill weighs less than a smartphone.\n\nSCARLET MACAW — Can live over 75 years. Our oldest, Captain, is 42.' }));
-    aviaryPlaque.add(new SceneryTrait());
     world.moveEntity(aviaryPlaque.id, aviary.id);
 
     const warningSign = world.createEntity('warning sign', EntityType.SCENERY);
     warningSign.add(new IdentityTrait({ name: 'warning sign', description: 'A yellow warning sign near the nocturnal exhibit entrance.', aliases: ['warning', 'warning sign', 'yellow sign'], properName: false, article: 'a' }));
     warningSign.add(new ReadableTrait({ text: 'CAUTION: The Nocturnal Animals Exhibit is kept dark. Please use a flashlight. Do NOT use camera flash. (We don\'t talk about the Great Owl Incident of 2022.)' }));
-    warningSign.add(new SceneryTrait());
     world.moveEntity(warningSign.id, supplyRoom.id);
 
     const brochure = world.createEntity('zoo brochure', EntityType.ITEM);
@@ -513,19 +508,16 @@ class FamilyZooStory implements Story {
 
     const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
     goats.add(new IdentityTrait({ name: 'pygmy goats', grammaticalNumber: 'plural', description: 'Three pygmy goats hoping you have food.', aliases: ['goats', 'pygmy goats', 'goat'], properName: false, article: 'some' }));
-    goats.add(new SceneryTrait());
     goats.add(new PettableTrait('goats'));  // ← PettableTrait with 'goats' kind
     world.moveEntity(goats.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
     rabbits.add(new IdentityTrait({ name: 'rabbits', grammaticalNumber: 'plural', description: 'A pair of Holland Lop rabbits with floppy ears.', aliases: ['rabbits', 'rabbit', 'bunnies'], properName: false, article: 'some' }));
-    rabbits.add(new SceneryTrait());
     rabbits.add(new PettableTrait('rabbits'));  // ← PettableTrait with 'rabbits' kind
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
     parrots.add(new IdentityTrait({ name: 'parrots', grammaticalNumber: 'plural', description: 'A raucous flock of scarlet macaws and grey African parrots.', aliases: ['parrots', 'macaws', 'birds'], properName: false, article: 'some' }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     // PORTABLE OBJECTS

--- a/tutorials/familyzoo/src/ch20-npcs.ts
+++ b/tutorials/familyzoo/src/ch20-npcs.ts
@@ -483,14 +483,12 @@ class FamilyZooStory implements Story {
     ] as [string, string, string[], IFEntity][]) {
       const e = world.createEntity(name, EntityType.SCENERY);
       e.add(new IdentityTrait({ name, description: desc, aliases, properName: false, article: 'a' }));
-      e.add(new SceneryTrait());
       world.moveEntity(e.id, room.id);
     }
 
     // Additional scenery with special traits (readable, switchable)
     const corkBoard = world.createEntity('cork board', EntityType.SCENERY);
     corkBoard.add(new IdentityTrait({ name: 'cork board', description: 'A cork board with staff schedules. A note in red marker: "DON\'T FORGET: nocturnal exhibit lights need new batteries!"', aliases: ['cork board', 'board', 'notices'], properName: false, article: 'a' }));
-    corkBoard.add(new SceneryTrait());
     world.moveEntity(corkBoard.id, supplyRoom.id);
 
     const radio = world.createEntity('radio', EntityType.ITEM);
@@ -502,19 +500,16 @@ class FamilyZooStory implements Story {
     const pettingPlaque = world.createEntity('info plaque', EntityType.SCENERY);
     pettingPlaque.add(new IdentityTrait({ name: 'info plaque', description: 'A brass plaque mounted on a wooden post near the petting zoo gate.', aliases: ['plaque', 'info plaque', 'brass plaque'], properName: false, article: 'an' }));
     pettingPlaque.add(new ReadableTrait({ text: 'PYGMY GOATS — These Nigerian Dwarf goats are gentle, curious, and always hungry.\n\nHOLLAND LOP RABBITS — Known for their floppy ears. Our pair, Biscuit and Marmalade, were born here in 2023.' }));
-    pettingPlaque.add(new SceneryTrait());
     world.moveEntity(pettingPlaque.id, pettingZoo.id);
 
     const aviaryPlaque = world.createEntity('aviary plaque', EntityType.SCENERY);
     aviaryPlaque.add(new IdentityTrait({ name: 'aviary plaque', description: 'A colorful information board near the aviary entrance.', aliases: ['plaque', 'aviary plaque', 'information board'], properName: false, article: 'an' }));
     aviaryPlaque.add(new ReadableTrait({ text: 'WELCOME TO THE AVIARY — Home to over 30 species!\n\nTOCO TOUCAN — Its bill weighs less than a smartphone.\n\nSCARLET MACAW — Can live over 75 years. Our oldest, Captain, is 42.' }));
-    aviaryPlaque.add(new SceneryTrait());
     world.moveEntity(aviaryPlaque.id, aviary.id);
 
     const warningSign = world.createEntity('warning sign', EntityType.SCENERY);
     warningSign.add(new IdentityTrait({ name: 'warning sign', description: 'A yellow warning sign near the nocturnal exhibit entrance.', aliases: ['warning', 'warning sign', 'yellow sign'], properName: false, article: 'a' }));
     warningSign.add(new ReadableTrait({ text: 'CAUTION: The Nocturnal Animals Exhibit is kept dark. Please use a flashlight. Do NOT use camera flash. (We don\'t talk about the Great Owl Incident of 2022.)' }));
-    warningSign.add(new SceneryTrait());
     world.moveEntity(warningSign.id, supplyRoom.id);
 
     const brochure = world.createEntity('zoo brochure', EntityType.ITEM);
@@ -530,19 +525,16 @@ class FamilyZooStory implements Story {
 
     const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
     goats.add(new IdentityTrait({ name: 'pygmy goats', grammaticalNumber: 'plural', description: 'Three pygmy goats hoping you have food.', aliases: ['goats', 'pygmy goats', 'goat'], properName: false, article: 'some' }));
-    goats.add(new SceneryTrait());
     goats.add(new PettableTrait('goats'));  // ← PettableTrait with 'goats' kind
     world.moveEntity(goats.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
     rabbits.add(new IdentityTrait({ name: 'rabbits', grammaticalNumber: 'plural', description: 'A pair of Holland Lop rabbits with floppy ears.', aliases: ['rabbits', 'rabbit', 'bunnies'], properName: false, article: 'some' }));
-    rabbits.add(new SceneryTrait());
     rabbits.add(new PettableTrait('rabbits'));  // ← PettableTrait with 'rabbits' kind
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
     parrots.add(new IdentityTrait({ name: 'parrots', grammaticalNumber: 'plural', description: 'A raucous flock of scarlet macaws and grey African parrots.', aliases: ['parrots', 'macaws', 'birds'], properName: false, article: 'some' }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     // PORTABLE OBJECTS

--- a/tutorials/familyzoo/src/ch22-timed-events.ts
+++ b/tutorials/familyzoo/src/ch22-timed-events.ts
@@ -562,14 +562,12 @@ class FamilyZooStory implements Story {
     ] as [string, string, string[], IFEntity][]) {
       const e = world.createEntity(name, EntityType.SCENERY);
       e.add(new IdentityTrait({ name, description: desc, aliases, properName: false, article: 'a' }));
-      e.add(new SceneryTrait());
       world.moveEntity(e.id, room.id);
     }
 
     // Additional scenery with special traits — Same as V14
     const corkBoard = world.createEntity('cork board', EntityType.SCENERY);
     corkBoard.add(new IdentityTrait({ name: 'cork board', description: 'A cork board with staff schedules. A note in red marker: "DON\'T FORGET: nocturnal exhibit lights need new batteries!"', aliases: ['cork board', 'board', 'notices'], properName: false, article: 'a' }));
-    corkBoard.add(new SceneryTrait());
     world.moveEntity(corkBoard.id, supplyRoom.id);
 
     const radio = world.createEntity('radio', EntityType.ITEM);
@@ -581,19 +579,16 @@ class FamilyZooStory implements Story {
     const pettingPlaque = world.createEntity('info plaque', EntityType.SCENERY);
     pettingPlaque.add(new IdentityTrait({ name: 'info plaque', description: 'A brass plaque mounted on a wooden post near the petting zoo gate.', aliases: ['plaque', 'info plaque', 'brass plaque'], properName: false, article: 'an' }));
     pettingPlaque.add(new ReadableTrait({ text: 'PYGMY GOATS — These Nigerian Dwarf goats are gentle, curious, and always hungry.\n\nHOLLAND LOP RABBITS — Known for their floppy ears. Our pair, Biscuit and Marmalade, were born here in 2023.' }));
-    pettingPlaque.add(new SceneryTrait());
     world.moveEntity(pettingPlaque.id, pettingZoo.id);
 
     const aviaryPlaque = world.createEntity('aviary plaque', EntityType.SCENERY);
     aviaryPlaque.add(new IdentityTrait({ name: 'aviary plaque', description: 'A colorful information board near the aviary entrance.', aliases: ['plaque', 'aviary plaque', 'information board'], properName: false, article: 'an' }));
     aviaryPlaque.add(new ReadableTrait({ text: 'WELCOME TO THE AVIARY — Home to over 30 species!\n\nTOCO TOUCAN — Its bill weighs less than a smartphone.\n\nSCARLET MACAW — Can live over 75 years. Our oldest, Captain, is 42.' }));
-    aviaryPlaque.add(new SceneryTrait());
     world.moveEntity(aviaryPlaque.id, aviary.id);
 
     const warningSign = world.createEntity('warning sign', EntityType.SCENERY);
     warningSign.add(new IdentityTrait({ name: 'warning sign', description: 'A yellow warning sign near the nocturnal exhibit entrance.', aliases: ['warning', 'warning sign', 'yellow sign'], properName: false, article: 'a' }));
     warningSign.add(new ReadableTrait({ text: 'CAUTION: The Nocturnal Animals Exhibit is kept dark. Please use a flashlight. Do NOT use camera flash. (We don\'t talk about the Great Owl Incident of 2022.)' }));
-    warningSign.add(new SceneryTrait());
     world.moveEntity(warningSign.id, supplyRoom.id);
 
     const brochure = world.createEntity('zoo brochure', EntityType.ITEM);
@@ -604,19 +599,16 @@ class FamilyZooStory implements Story {
     // PETTABLE ANIMALS — Same as V14
     const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
     goats.add(new IdentityTrait({ name: 'pygmy goats', grammaticalNumber: 'plural', description: 'Three pygmy goats hoping you have food.', aliases: ['goats', 'pygmy goats', 'goat'], properName: false, article: 'some' }));
-    goats.add(new SceneryTrait());
     goats.add(new PettableTrait('goats'));
     world.moveEntity(goats.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
     rabbits.add(new IdentityTrait({ name: 'rabbits', grammaticalNumber: 'plural', description: 'A pair of Holland Lop rabbits with floppy ears.', aliases: ['rabbits', 'rabbit', 'bunnies'], properName: false, article: 'some' }));
-    rabbits.add(new SceneryTrait());
     rabbits.add(new PettableTrait('rabbits'));
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
     parrots.add(new IdentityTrait({ name: 'parrots', grammaticalNumber: 'plural', description: 'A raucous flock of scarlet macaws and grey African parrots.', aliases: ['parrots', 'macaws', 'birds'], properName: false, article: 'some' }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     // PORTABLE OBJECTS — Same as V14

--- a/tutorials/familyzoo/src/ch23-scoring.ts
+++ b/tutorials/familyzoo/src/ch23-scoring.ts
@@ -583,14 +583,12 @@ class FamilyZooStory implements Story {
     ] as [string, string, string[], IFEntity][]) {
       const e = world.createEntity(name, EntityType.SCENERY);
       e.add(new IdentityTrait({ name, description: desc, aliases, properName: false, article: 'a' }));
-      e.add(new SceneryTrait());
       world.moveEntity(e.id, room.id);
     }
 
     // Additional scenery with special traits
     const corkBoard = world.createEntity('cork board', EntityType.SCENERY);
     corkBoard.add(new IdentityTrait({ name: 'cork board', description: 'A cork board with staff schedules. A note in red marker: "DON\'T FORGET: nocturnal exhibit lights need new batteries!"', aliases: ['cork board', 'board', 'notices'], properName: false, article: 'a' }));
-    corkBoard.add(new SceneryTrait());
     world.moveEntity(corkBoard.id, supplyRoom.id);
 
     const radio = world.createEntity('radio', EntityType.ITEM);
@@ -602,19 +600,16 @@ class FamilyZooStory implements Story {
     const pettingPlaque = world.createEntity('info plaque', EntityType.SCENERY);
     pettingPlaque.add(new IdentityTrait({ name: 'info plaque', description: 'A brass plaque mounted on a wooden post near the petting zoo gate.', aliases: ['plaque', 'info plaque', 'brass plaque'], properName: false, article: 'an' }));
     pettingPlaque.add(new ReadableTrait({ text: 'PYGMY GOATS — These Nigerian Dwarf goats are gentle, curious, and always hungry.\n\nHOLLAND LOP RABBITS — Known for their floppy ears. Our pair, Biscuit and Marmalade, were born here in 2023.' }));
-    pettingPlaque.add(new SceneryTrait());
     world.moveEntity(pettingPlaque.id, pettingZoo.id);
 
     const aviaryPlaque = world.createEntity('aviary plaque', EntityType.SCENERY);
     aviaryPlaque.add(new IdentityTrait({ name: 'aviary plaque', description: 'A colorful information board near the aviary entrance.', aliases: ['plaque', 'aviary plaque', 'information board'], properName: false, article: 'an' }));
     aviaryPlaque.add(new ReadableTrait({ text: 'WELCOME TO THE AVIARY — Home to over 30 species!\n\nTOCO TOUCAN — Its bill weighs less than a smartphone.\n\nSCARLET MACAW — Can live over 75 years. Our oldest, Captain, is 42.' }));
-    aviaryPlaque.add(new SceneryTrait());
     world.moveEntity(aviaryPlaque.id, aviary.id);
 
     const warningSign = world.createEntity('warning sign', EntityType.SCENERY);
     warningSign.add(new IdentityTrait({ name: 'warning sign', description: 'A yellow warning sign near the nocturnal exhibit entrance.', aliases: ['warning', 'warning sign', 'yellow sign'], properName: false, article: 'a' }));
     warningSign.add(new ReadableTrait({ text: 'CAUTION: The Nocturnal Animals Exhibit is kept dark. Please use a flashlight. Do NOT use camera flash. (We don\'t talk about the Great Owl Incident of 2022.)' }));
-    warningSign.add(new SceneryTrait());
     world.moveEntity(warningSign.id, supplyRoom.id);
 
     const brochure = world.createEntity('zoo brochure', EntityType.ITEM);
@@ -626,19 +621,16 @@ class FamilyZooStory implements Story {
     // PETTABLE ANIMALS
     const goats = world.createEntity('pygmy goats', EntityType.SCENERY);
     goats.add(new IdentityTrait({ name: 'pygmy goats', grammaticalNumber: 'plural', description: 'Three pygmy goats hoping you have food.', aliases: ['goats', 'pygmy goats', 'goat'], properName: false, article: 'some' }));
-    goats.add(new SceneryTrait());
     goats.add(new PettableTrait('goats'));
     world.moveEntity(goats.id, pettingZoo.id);
 
     const rabbits = world.createEntity('rabbits', EntityType.SCENERY);
     rabbits.add(new IdentityTrait({ name: 'rabbits', grammaticalNumber: 'plural', description: 'A pair of Holland Lop rabbits with floppy ears.', aliases: ['rabbits', 'rabbit', 'bunnies'], properName: false, article: 'some' }));
-    rabbits.add(new SceneryTrait());
     rabbits.add(new PettableTrait('rabbits'));
     world.moveEntity(rabbits.id, pettingZoo.id);
 
     const parrots = world.createEntity('parrots', EntityType.SCENERY);
     parrots.add(new IdentityTrait({ name: 'parrots', grammaticalNumber: 'plural', description: 'A raucous flock of scarlet macaws and grey African parrots.', aliases: ['parrots', 'macaws', 'birds'], properName: false, article: 'some' }));
-    parrots.add(new SceneryTrait());
     world.moveEntity(parrots.id, aviary.id);
 
     // PORTABLE OBJECTS


### PR DESCRIPTION
## Summary

ADR-189 made `createEntity(name, EntityType.SCENERY)` auto-add a `SceneryTrait` (shipped in `world-model@1.2.0`). This PR aligns the book and the Family Zoo tutorial to that behavior: the redundant explicit `SceneryTrait` adds are removed from SCENERY-typed entities, and the prose updated to teach "the `EntityType.SCENERY` type carries the behavior."

## Book (`docs/book/parts/`)
- **ch05** fully reworked (option C): the "label and the trait" footgun section is replaced by "when you still add `SceneryTrait` by hand" (only for non-SCENERY fixed things or a custom refusal); both redundant adds dropped; em-dash fixes folded in.
- Redundant SCENERY `SceneryTrait` adds removed in **ch02, 04, 07, 08, 12** (12 sites); stale prose/comments that described the removed adds fixed in ch02, ch04, ch12.
- Non-SCENERY fixed things keep their explicit `SceneryTrait` (dispenser=CONTAINER, parkBench=SUPPORTER, staffGate=DOOR, radio=ITEM, souvenirPress=CONTAINER).

## Tutorial (`tutorials/familyzoo/`)
- Redundant SCENERY adds removed across **13 `ch*.ts` files** (158 sites); 46 non-SCENERY adds kept.
- `package.json` `@sharpee/*` deps corrected to the real published versions (`world-model`/`lang-en-us`/`stdlib` `^1.2.0`, the rest at their actual `1.1.x`); `pnpm-lock.yaml` updated.

## Validation
- familyzoo **builds clean** on 1.2.0 (TypeScript + `.sharpee` bundle + browser client).
- Published `world-model@1.2.0` auto-adds `SceneryTrait` to SCENERY, not to ITEM (verified directly).
- familyzoo's **ch05 story** runs on 1.2.0 with scenery fixed (`iron fence`, `rabbits`) and items portable (`zoo map`, `bag of animal feed`) — exactly what the v01/v03 transcripts assert.

## Follow-ups (not in this PR)
- The three packages are published at `1.2.0` but should have been the next `1.1.x` patch (incremental line); a corrected republish + matching familyzoo dep update is pending.
- Full v01–v16 transcript suite needs the in-repo CLI bundle rebuilt (`./repokit build`) to clear a stale-bundle `world.helpers()` split; standalone behavior is already confirmed.
- dungeo (in-repo test story) may have its own redundant SCENERY adds; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
