### PR TITLE
ADR-289 D7 — verify gates raw control bytes in source (closes F5)

### DIFF
--- a/docs/architecture/adrs/adr-289-chord-routing-decided-once.md
+++ b/docs/architecture/adrs/adr-289-chord-routing-decided-once.md
@@ -501,6 +501,23 @@ reads it. This is not cosmetic: it silently blanks the file from every
 search, including searches by agents, and it is the reason this review's
 runtime findings could not be reproduced by grep on the first attempt.
 
+#### D7 note — the class is now gated, not just the instances (2026-07-29)
+
+D7 fixed two bytes in one file. That did not close the class, and the class
+reopened twice during this ADR's own implementation — once in `analyzer.ts`,
+once in the character class of the gate written to catch it.
+
+`repokit verify` now refuses any raw C0 control (except tab, newline, carriage
+return) or DEL in text sources, reported with file, line and codepoint —
+`tools/repokit/src/commands/control-bytes.ts`, beside the ADR-269 D7 and
+ADR-276 D2 freshness gates it is modelled on. Clearing the tree for it turned
+up **six pre-existing sites** in three packages that had nothing to do with
+this ADR, which is the measure of how invisible the defect is: `tsc` compiles
+it, tests pass, and search reports no matches rather than an error.
+
+Verified by planting a NUL and watching `verify` exit 1, then removing it and
+watching it exit 0 — not by reading the code. See followups F5 (closed).
+
 ### D8 — Review disposition: every remaining item ships, defers, or is declined
 
 Shipping with the above, each being a one-site fix in a file already open:

--- a/docs/work/adr-289-chord-routing-decided-once/followups.md
+++ b/docs/work/adr-289-chord-routing-decided-once/followups.md
@@ -107,9 +107,34 @@ walk; if it is, D3's wording should say so.
 
 ---
 
-## F5 — Nothing stops a raw control byte from entering source
+## F5 — Nothing stops a raw control byte from entering source — **CLOSED 2026-07-29**
 
-**Severity: low frequency, high blast radius — and now demonstrated twice.**
+**Resolution.** `repokit verify` gained the gate: `tools/repokit/src/commands/
+control-bytes.ts`, wired in beside the ADR-269 D7 / ADR-276 D2 freshness gates
+it was modelled on. Every C0 control except tab, newline and carriage return —
+plus DEL — is a build failure in text sources, reported with file, line and
+codepoint. Build output, dependencies, sourcemaps and golden snapshots are out
+of scope by construction (an allowlist of text extensions, not a denylist).
+
+Before it could land, the class had to be cleared: a repo sweep of 7,046 text
+files found **eight** offending lines across seven files — two written during
+ADR-289 itself, **six pre-existing** (`lang-en-us` assembler tests ×4,
+`generate-standard-grammar-chord.cjs` ×2, a raw ESC in
+`fenced-reporter.test.ts`). All were rewritten as escapes, behaviour-identical.
+
+**Verified by planting, not by reasoning:** a raw NUL was written into
+`packages/chord/src/version.ts` and `repokit verify` exited 1 naming the site;
+removing it returned exit 0. Ten unit tests cover the gate itself, including
+that the *escape* form — the fix the gate demands — does not trip it.
+
+**One more data point for the class, collected while closing it.** The first
+draft of the gate's own source contained a raw control byte, in the character
+class meant to match raw control bytes. It was caught by the sweeper, not by
+review, `tsc`, or the eye. That is now three instances written by someone who
+knew exactly what the defect was and was actively looking for it — which is the
+argument for a mechanical gate stated as well as it can be stated.
+
+**Severity (as recorded before closure): low frequency, high blast radius.**
 
 D7 fixed two literal NULs in `runtime.ts`. Implementing D5 I put a fresh one
 into `analyzer.ts`, in the `registerUnique` key join, and it had exactly the

--- a/tools/repokit/src/commands/control-bytes.test.ts
+++ b/tools/repokit/src/commands/control-bytes.test.ts
@@ -1,0 +1,127 @@
+/**
+ * control-bytes.test.ts — the ADR-289 D7 gate.
+ *
+ * Guards the search-lies class: a raw NUL makes search tooling treat a file as
+ * binary and return NOTHING for every query against it, while `tsc` compiles it
+ * and every test passes. The gate is the only thing in the toolchain that can
+ * see one, so these tests pin that it does — and, just as importantly, that it
+ * does not fire on the escapes that are the correct way to write the same byte.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { findControlBytes, formatControlByteFailure } from './control-bytes';
+
+let roots: string[] = [];
+
+function repo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'repokit-ctlbytes-test-'));
+  roots.push(root);
+  return root;
+}
+
+function write(root: string, relative: string, text: string): void {
+  const full = join(root, relative);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, text);
+}
+
+/** Built at runtime so this test file never contains a raw control byte itself. */
+const NUL = String.fromCharCode(0);
+const ESC = String.fromCharCode(27);
+const DEL = String.fromCharCode(127);
+
+afterEach(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots = [];
+});
+
+describe('findControlBytes', () => {
+  it('a clean tree yields nothing', () => {
+    const root = repo();
+    write(root, 'packages/chord/src/analyzer.ts', 'const key = `${a}\\u0000${b}`;\n');
+    write(root, 'docs/adr.md', '# Fine\n\nTabs\tand newlines are text.\n');
+    expect(findControlBytes(root)).toEqual([]);
+  });
+
+  it('catches a raw NUL and reports its file, line and codepoint', () => {
+    const root = repo();
+    write(root, 'packages/chord/src/analyzer.ts', `const a = 1;\nconst key = \`x${NUL}y\`;\n`);
+    const hits = findControlBytes(root);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].file).toBe(join('packages', 'chord', 'src', 'analyzer.ts'));
+    expect(hits[0].line).toBe(2);
+    expect(hits[0].codepoints).toEqual(['U+0000']);
+  });
+
+  it('catches ESC and DEL too, not just NUL', () => {
+    const root = repo();
+    write(root, 'a.ts', `const strip = /${ESC}\\[[0-9]*m/;\n`);
+    write(root, 'b.ts', `const x = "${DEL}";\n`);
+    const codepoints = findControlBytes(root).flatMap((h) => h.codepoints);
+    expect(codepoints).toContain('U+001B');
+    expect(codepoints).toContain('U+007F');
+  });
+
+  it('the escape form — the fix the gate asks for — does NOT fire', () => {
+    const root = repo();
+    // The literal characters backslash-u-0-0-0-0, which is what D7 requires.
+    write(root, 'a.ts', 'const key = `${ns}\\u0000${name}`;\n');
+    expect(findControlBytes(root)).toEqual([]);
+  });
+
+  it('tab, newline and carriage return are text, not control bytes', () => {
+    const root = repo();
+    write(root, 'a.ts', 'const a = 1;\r\n\tconst b = 2;\r\n');
+    expect(findControlBytes(root)).toEqual([]);
+  });
+
+  it('skips build output and dependencies — a bundled NUL is not source', () => {
+    const root = repo();
+    write(root, 'packages/chord/dist/index.js', `x${NUL}y\n`);
+    write(root, 'packages/chord/dist-esm/index.js', `x${NUL}y\n`);
+    write(root, 'node_modules/dep/index.js', `x${NUL}y\n`);
+    write(root, 'coverage/report.json', `{"x":"${NUL}"}\n`);
+    expect(findControlBytes(root)).toEqual([]);
+  });
+
+  it('skips binary and snapshot file types', () => {
+    const root = repo();
+    // Not in the allowlist: a sourcemap and a golden snapshot, both of which
+    // can legitimately carry control bytes.
+    write(root, 'a.js.map', `{"x":"${NUL}"}\n`);
+    write(root, 'tests/__snapshots__/a.test.ts.snap', `exports[\`x\`] = \`${ESC}[0m\`;\n`);
+    expect(findControlBytes(root)).toEqual([]);
+  });
+
+  it('reports every offending line, not just the first', () => {
+    const root = repo();
+    write(root, 'a.ts', `const a = "${NUL}";\nconst b = 2;\nconst c = "${NUL}";\n`);
+    const hits = findControlBytes(root);
+    expect(hits.map((h) => h.line)).toEqual([1, 3]);
+  });
+});
+
+describe('formatControlByteFailure', () => {
+  it('names each site and the remedy', () => {
+    const message = formatControlByteFailure([
+      { file: 'packages/chord/src/analyzer.ts', line: 2635, codepoints: ['U+0000'] },
+    ]);
+    expect(message).toContain('packages/chord/src/analyzer.ts:2635');
+    expect(message).toContain('U+0000');
+    expect(message).toContain('ADR-289 D7');
+    expect(message).toContain('escape');
+  });
+
+  it('truncates a long list rather than flooding the console', () => {
+    const many = Array.from({ length: 25 }, (_, i) => ({
+      file: `a${i}.ts`,
+      line: i + 1,
+      codepoints: ['U+0000'],
+    }));
+    const message = formatControlByteFailure(many);
+    expect(message).toContain('and 5 more');
+    expect(message).toContain('25 raw control byte(s)');
+  });
+});

--- a/tools/repokit/src/commands/control-bytes.ts
+++ b/tools/repokit/src/commands/control-bytes.ts
@@ -1,0 +1,135 @@
+/**
+ * control-bytes.ts — the ADR-289 D7 gate: no raw control bytes in source.
+ *
+ * D7 ruled that a control character belongs in source as an ESCAPE, never as a
+ * raw byte, and fixed the two instances it knew about (`runtime.ts`'s NUL join
+ * separator). It did not close the class: a repo sweep during ADR-289 Phase 6
+ * found eight offending lines across six more files, four of them predating the
+ * ADR entirely, and one written *during* its own implementation.
+ *
+ * The failure mode is why this is a build gate rather than a lint preference.
+ * A raw NUL makes most search tooling treat the file as binary and silently
+ * return NOTHING for every query against it — `grep` reports no matches in a
+ * 4,400-line file rather than reporting an error. `tsc` compiles it happily (a
+ * NUL inside a template literal is valid TypeScript), no test fails, and the
+ * only symptom is that search lies to whoever comes next, human or agent.
+ * Nothing else in the toolchain can see it, so nothing else can gate it.
+ *
+ * Tab, newline and carriage return are exempt — they are legitimate text.
+ * Everything else in C0 (and DEL) is refused with its file, line and codepoint.
+ *
+ * Public interface: findControlBytes, ControlByteHit.
+ * Owner context: tools/repokit — the in-repo platform build tool (unpublished).
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/** Directories never scanned: build output, dependencies, VCS, caches. */
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'dist-esm',
+  'dist-web',
+  'coverage',
+  '.turbo',
+  '.next',
+  'build',
+]);
+
+/**
+ * Text file types this gate owns. An allowlist, not a denylist: binary formats
+ * (images, fonts, archives, sourcemaps) are full of control bytes by nature and
+ * must never be scanned. `.snap` is deliberately absent — a golden snapshot may
+ * legitimately capture escape sequences from terminal output.
+ */
+const TEXT_EXT = /\.(ts|tsx|js|jsx|mjs|cjs|json|md|story|ebnf|transcript|yml|yaml|css|html|sh)$/;
+
+/** Raw C0 controls except tab (09), newline (0a), carriage return (0d); plus DEL (7f). */
+// eslint-disable-next-line no-control-regex
+const RAW_CONTROL = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/;
+
+/** One offending line. */
+export interface ControlByteHit {
+  /** Repo-relative path. */
+  file: string;
+  /** 1-based line number. */
+  line: number;
+  /** The offending codepoints, as `U+XXXX` strings, in first-seen order. */
+  codepoints: string[];
+}
+
+/** Every raw control byte in one file's text, by line. */
+function scanText(text: string, file: string): ControlByteHit[] {
+  const hits: ControlByteHit[] = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (!RAW_CONTROL.test(lines[i])) continue;
+    const seen = new Set<string>();
+    for (const ch of lines[i]) {
+      if (!RAW_CONTROL.test(ch)) continue;
+      seen.add('U+' + ch.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0'));
+    }
+    hits.push({ file, line: i + 1, codepoints: [...seen] });
+  }
+  return hits;
+}
+
+/**
+ * Walk the repo for raw control bytes in text sources.
+ *
+ * @param root repo root to scan from
+ * @returns every offending line, in walk order; empty when the tree is clean
+ */
+export function findControlBytes(root: string): ControlByteHit[] {
+  const hits: ControlByteHit[] = [];
+
+  const walk = (dir: string): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return; // unreadable directory is not this gate's business
+    }
+    for (const name of entries) {
+      if (SKIP_DIRS.has(name)) continue;
+      const path = join(dir, name);
+      let st;
+      try {
+        st = statSync(path);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        walk(path);
+        continue;
+      }
+      if (!TEXT_EXT.test(name)) continue;
+      // latin1 so every byte survives the read: a decode to UTF-8 could turn
+      // an invalid sequence into U+FFFD and hide the very byte being hunted.
+      hits.push(...scanText(readFileSync(path, 'latin1'), relative(root, path)));
+    }
+  };
+
+  walk(root);
+  return hits;
+}
+
+/**
+ * Format the gate's failure for the console.
+ *
+ * @param hits offending lines from {@link findControlBytes}
+ * @returns a multi-line message naming each site and the fix
+ */
+export function formatControlByteFailure(hits: ControlByteHit[]): string {
+  const shown = hits.slice(0, 20);
+  const lines = shown.map((h) => `  ${h.file}:${h.line}  ${h.codepoints.join(' ')}`);
+  if (hits.length > shown.length) lines.push(`  … and ${hits.length - shown.length} more`);
+  return [
+    `verify: ${hits.length} raw control byte(s) in source (ADR-289 D7) —`,
+    ...lines,
+    '  Write the character as an escape (e.g. `\\u0000`) instead of a raw byte:',
+    '  a raw control byte makes search tooling treat the file as binary and',
+    '  silently report NO matches for every query against it.',
+  ].join('\n');
+}

--- a/tools/repokit/src/commands/verify.ts
+++ b/tools/repokit/src/commands/verify.ts
@@ -10,6 +10,7 @@
 import { execFileSync } from 'node:child_process';
 import { findRepoRoot, tsfBin } from '../repo';
 import { Command } from './command';
+import { findControlBytes, formatControlByteFailure } from './control-bytes';
 import { checkDocsBlocksModule, checkGrammarModule } from './grammar';
 import { checkManifestModule } from './manifest';
 
@@ -45,6 +46,17 @@ export class VerifyCommand implements Command {
       console.error(
         'verify: chord/src/stdlib-manifest.ts is STALE against the stdlib action surface — run `repokit manifest` and commit.',
       );
+      return 1;
+    }
+
+    // ADR-289 D7: a raw control byte in source is a build error. Nothing else
+    // in the toolchain can see one — tsc compiles it, tests pass, and search
+    // silently reports no matches for the whole file — so nothing else can
+    // gate it.
+    log('=== repokit verify: control bytes ===');
+    const controlBytes = findControlBytes(root);
+    if (controlBytes.length > 0) {
+      console.error(formatControlByteFailure(controlBytes));
       return 1;
     }
 


### PR DESCRIPTION
Closes follow-up **F5** from ADR-289.

D7 fixed two raw NULs in `runtime.ts`. It did not close the class — and the class reopened **twice during ADR-289's own implementation**: once in `analyzer.ts`, and once in the character class of the gate written to catch it.

## The gate

`repokit verify` now refuses any raw C0 control byte (except tab, newline, carriage return) plus DEL in text sources, reporting file, line and codepoint. It sits beside the ADR-269 D7 and ADR-276 D2 freshness gates it's modelled on.

```
=== repokit verify: control bytes ===
verify: 1 raw control byte(s) in source (ADR-289 D7) —
  packages/chord/src/version.ts:1  U+0000
  Write the character as an escape (e.g. \u0000) instead of a raw byte:
  a raw control byte makes search tooling treat the file as binary and
  silently report NO matches for every query against it.
```

## Why a build gate rather than a lint rule

A raw NUL makes search tooling treat the file as binary and silently return **nothing** for every query against it — `grep` reports no matches in a 4,400-line file rather than reporting an error. `tsc` compiles it happily (a NUL inside a template literal is valid TypeScript), no test fails, and the only symptom is that search lies to whoever comes next, human or agent. Nothing else in the toolchain can see it, so nothing else can gate it.

Scope is an **allowlist** of text extensions, never a denylist — sourcemaps, images and golden snapshots legitimately carry control bytes and stay out of scope, as do `dist/`, `dist-esm/`, `node_modules/` and `coverage/`.

## What clearing the tree turned up

Six **pre-existing** sites unrelated to this ADR — `lang-en-us` assembler tests x4, the standard-grammar codegen script x2, and a raw ESC in `fenced-reporter.test.ts`. All were rewritten as escapes in the phase-6 commit, behaviour-identical, suites green. That's the measure of how invisible the defect is.

## Verification

Planted rather than reasoned about: a raw NUL written into `version.ts` made `repokit verify` **exit 1** naming the site; removing it returned **exit 0**. Ten unit tests cover the gate itself — including that the *escape* form (the fix the gate demands) does not trip it, that tab/newline/CR are text, and that build output is skipped.

repokit 64 passed | 1 skipped. `repokit verify` green across 32 packages.

One note worth keeping: the first draft of this gate's own source contained a raw control byte, in the character class meant to match raw control bytes. It was caught by the sweeper — not by review, not by `tsc`, not by eye. Three instances now, all written by someone who knew exactly what the defect was and was actively looking for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
