### PR TITLE
engine: merge save/restore hooks (#229); ADR-303 convergent paths and unwinnable states

### DIFF
--- a/docs/architecture/adrs/adr-131-automated-world-explorer.md
+++ b/docs/architecture/adrs/adr-131-automated-world-explorer.md
@@ -1,7 +1,25 @@
 # ADR-131: Automated World Explorer (Regression Test Generator)
 
-**Status:** Proposed
+**Status:** Proposed — and **unbuilt** as of 2026-08-05: nothing in `packages/`
+or `repokit` implements it.
 **Date:** 2026-02-18
+
+> **SCOPE QUESTION OPENED 2026-08-05 (session f2a7e6)** — see
+> [ADR-303 Q-3](adr-303-convergent-paths-and-unwinnable-states.md). This ADR is
+> a *regression-baseline generator*, and says so: BFS the rooms, probe entities
+> and description nouns, record outputs, diff later. It excludes reachability by
+> design — "This avoids the hard problem of puzzle-solving."
+>
+> The open question is whether the same BFS bot should also probe whether the
+> **ending stays reachable** — an unwinnable state has no ending, no message and
+> no test, which is why it survives to ship (ADR-303 D1). That is the excluded
+> thing, so widening this ADR would replace its stated premise rather than
+> extend it, and the alternative is a separate tool.
+>
+> Note also that the *static* half already ships elsewhere:
+> `tools/vscode-ext/src/world-explorer.ts` renders a World Index from
+> `--world-json` with dead-end and one-way-exit highlighting. Whether that moves
+> to the IDE is part of Q-3.
 
 ## Context
 

--- a/docs/architecture/adrs/adr-302-transcript-branches.md
+++ b/docs/architecture/adrs/adr-302-transcript-branches.md
@@ -611,6 +611,28 @@ chosen — the first changes a public engine contract to preserve a mechanism th
 decision removes, and the second leaves the trap armed for the next caller while
 buying a 6% saving on the only story that uses it.
 
+> **THE FIRST WAS ADOPTED AFTER ALL, 2026-08-05 (session f2a7e6, David's
+> call) — and it does not undo this decision.** The rejection above is sound
+> only while the tree walk is the collision's one victim, which is what a
+> survey after D17 landed disproved: `registerSaveRestoreHooks` still had four
+> callers across the two harnesses — the ADR-300 D18 divergence save and the
+> `$save`/`$restore` directives in each `runner.ts`, and `searchOutcome`'s
+> per-candidate restore in each `search.ts` (issue #229). None is being
+> deleted, so "changes a public contract to preserve a mechanism this decision
+> removes" no longer describes the trade.
+>
+> `GameEngine.registerSaveRestoreHooks` now merges: a named entry replaces the
+> prior one of that name, unnamed entries survive, and removal is spelled by
+> naming an entry `undefined`. Merging necessarily **snapshots** — the engine
+> holds a copy rather than the caller's object, so mutating a registered hooks
+> object no longer reaches it.
+>
+> **D17 stands unchanged.** It is not a workaround that the engine fix
+> supersedes: re-execution was chosen on its own terms — the save format stops
+> being a correctness dependency of the harness, and the cost is 6.2% on the
+> representative corpus. The engine fix closes the *other* four callers, which
+> D17 never reached and never claimed to.
+
 ---
 
 ## Worked scenario

--- a/docs/architecture/adrs/adr-302-transcript-branches.md
+++ b/docs/architecture/adrs/adr-302-transcript-branches.md
@@ -4,6 +4,7 @@
 **Date**: 2026-08-05 (session 5113ca)
 **Supersedes in part**: ADR-300 D17 (chain membership as convention, not grammar)
 **Relates to**: ADR-293 (forcing, coverage, outcome search), ADR-294 D4 (`[IF:]` removed), ADR-299 (the skein's branching, superseded)
+**Questions raised by its usage**: [ADR-303](adr-303-convergent-paths-and-unwinnable-states.md) (DRAFT) — convergent paths, and unwinnable states as a divergence class. Raised *by* this ADR's use, not left unresolved *within* it: D1's one-parent rule is implemented and shipped, and ADR-303 reopens nothing here.
 
 ---
 

--- a/docs/architecture/adrs/adr-303-convergent-paths-and-unwinnable-states.md
+++ b/docs/architecture/adrs/adr-303-convergent-paths-and-unwinnable-states.md
@@ -1,0 +1,290 @@
+# ADR-303: Convergent Paths and Unwinnable States
+
+**Status**: **DRAFT** (2026-08-05, session f2a7e6) — all three open questions
+resolved by interview the same session (D4, D5, D6); awaiting review and the
+acceptance flip. Raised by usage after ADR-302 shipped, not by review of it.
+**Date**: 2026-08-05 (session f2a7e6)
+**Relates to**: ADR-302 (transcript branches), ADR-293 (forcing, coverage,
+outcome search), ADR-131 (automated world explorer), ADR-300 (canonical
+transcript)
+
+---
+
+## Context
+
+Two things ADR-302 did not consider. Both came from David on 2026-08-05, while
+reviewing the IDE's Testing surface — which is the point at which a model stops
+being a diagram and starts having to hold an author's real story.
+
+**Open world means paths reconverge.** The shape named was *"go to a room, do
+something, go to a room, do one of three things, go to a room."* ADR-302 D1
+gives a transcript at most one parent, so a story's tests are a forest by
+construction. The implementation says as much — `tree.ts`: *"Diamonds are
+unrepresentable and so need no check."* That dismisses the **validation**; it
+never asks whether an author would want one. A fork that reconverges has only
+two expressions today: duplicate the tail under each variant, or hang the tail
+off exactly one of them and leave the others as short leaves.
+
+This is not the question D1 settled. D1 rejected *interior addressing* —
+pointing at a turn inside another file — on the grounds that any insertion into
+the parent silently redirects the reference. Convergence is a different shape:
+whole files, whole references, several parents.
+
+**An unwinnable state is not a losing ending.** Fernhill authors two LOSE
+endings, `dawn-lose` and `fuse-lose`. Both have prose, both are reachable, both
+are tested. An unwinnable state has no ending, no message, and no test — the
+game continues, and the win has quietly become unreachable. That is precisely
+why it survives to ship: every other bad outcome announces itself.
+
+Both bear on **ADR-302 D6**, "an untaken branch is a coverage fact," which has
+no implementing phase, no acceptance criterion, and — until these two questions
+— no motivating case beyond `0 of 12 points fired`. (Note the collision of
+labels: *ADR-302 D6* is that coverage decision; *D6* below is this ADR's own
+sixth decision, about the explorer.)
+
+---
+
+## Decision
+
+D1–D3 are definitions; D4, D5 and D6 are mechanisms, each resolved by interview
+in session f2a7e6. Nothing remains open.
+
+**D1 — A loss is an outcome; unwinnability is a property of a state.** A loss is an
+authored ending: it has a name, prose, and a place in the point-and-class
+catalog (ADR-293 D2's catalog of points, D4's declared classes).
+Unwinnability is the *absence* of a reachable ending — a state from which no
+authored ending of the winning kind can be reached. They are not degrees of the
+same thing, and a catalog that enumerates the outcomes of choice points cannot
+express the second.
+
+**D2 — The transcript tree models the test suite, never the story.** The story
+is a cyclic graph: rooms connect both ways, states repeat, and the same world
+state is reachable by many routes. The suite is a set of paths through it. The
+IDE's branch view shows the suite and must not be read as a map of the world.
+(The Miller-column treatment of that view comes from the session f2a7e6 layout
+mocks, not from an ADR: ADR-301 is TBD and specifies no surface. Named here so
+the attribution is not laundered by repetition.) This matters because the two questions below
+both look like "the tree is wrong" and are actually "the tree is not the thing
+you are asking about."
+
+**D3 — Whether a fork's variants converge is a claim about the story, and the
+author states it.** Where a fork genuinely reconverges, running a long shared
+tail once per variant tests the same thing several times; where it does not,
+several tails are several honest tests that merely share a command list — which
+D7 already warns against reading as structure. The difference is not derivable
+from the files, so it is declared (D4).
+
+> **CORRECTED 2026-08-05, same session.** This decision first read "duplication
+> is the tripwire, not the defect", and argued that resolving Q-1 before an
+> author had duplicated a tail was speculative. David's ruling: *"that is a
+> legit and common puzzle sequence"* — several routes to one gate followed by a
+> common continuation is standard IF construction, not an edge case.
+>
+> The evidence used for "speculative" was that it had not appeared in
+> Fernhill's suite. The likelier reading is that **Fernhill's tests were written
+> to the tool's shape rather than the story's**: `containers` replays the sherry
+> toll under the note "proven fully in npcs.transcript", which is the
+> single-tail workaround being taken without anyone recording it as a choice. A
+> tool that quietly constrains the tests written against it produces exactly
+> this evidence, and it is not evidence of rarity.
+
+**D4 — A converging variant asserts its convergence; re-running the tail under
+every route is a per-fork opt-in.** (Resolves Q-1, session f2a7e6, David's
+call.) Two mechanisms, with the first as the default:
+
+**The assertion.** A variant declares that it arrives where a named sibling
+arrives — `converges-with: combination-diary` — and the harness *verifies* it
+before the shared tail runs once, off the named sibling. The claim is checked,
+not trusted, so "these three choices don't matter afterwards" stops being an
+assumption a suite silently rests on.
+
+**`converges-with` does not inherit.** ADR-302 D8 makes a transcript's effective
+header its parent's header with the child's declared fields replacing them — so
+without this clause a convergence assertion would flow down to every descendant
+and assert, on their behalf, a claim nobody wrote. The field is **declared-only**,
+read from the node that states it and never from an ancestor. This is the same
+keying `reseedFor` already uses for the seed instruments under D8's amendment
+(*"keyed on what the node DECLARED, never on its effective config"*), and for
+the same reason: inheritance is right for a *setting* and wrong for an
+*instruction*.
+
+**What must match is named by the author, never inferred.** Whole-world equality
+is the wrong test and would fail on everything true and irrelevant — turn
+counters, NPC patrol positions, RNG stream states all differ legitimately
+between routes. The author names the entities and facts that must agree. This
+is the same move ADR-293 makes for randomness and D7 makes for parentage: the
+platform does not guess what matters, it asks. Exact grammar is left to
+implementation; the decision is that the subset is authored.
+
+**Why the assertion beats brute force as the default.** Re-running the tail
+under all three routes does catch a divergence — forty turns later, inside a
+replayed tail, as a failure that does not name its cause. The assertion catches
+it at the fork, immediately, and the diagnostic is the sentence an author
+wants: *the world differs after `combination-tobias`*. It is both the cheaper
+check and the better error. That the classic bug of this shape ("the safe won't
+open if you got the combination from Tobias") is precisely what the single-tail
+status quo cannot catch is what makes the default worth having.
+
+**The opt-in.** An author who wants the tail genuinely re-run under each route
+says so per fork, by letting the tail name several parents. A node with N
+parents **expands to N runs**, each with a single ancestry — so every invariant
+that holds today holds per run: ancestry stays one chain, D17's amended AC-5
+becomes "a leaf costs its ancestry, summed over its parents", and the tree is a
+forest again after expansion. In the IDE the tail appears once under each route,
+which is what an alias does in several folders — the Finder idiom the branch
+view already borrows.
+
+Rejected: inferring convergence by diffing world state across siblings
+automatically. It would report every legitimate difference as a finding and
+train authors to ignore the surface, and it re-litigates D7 — a reading aid is
+never the truth.
+
+**D5 — Unwinnability is detected in three layers, and it is reported by the
+coverage surface without entering the point catalog.** (Resolves Q-2, session
+f2a7e6, David's call.)
+
+**Where it lives.** Not in ADR-293's **point-and-class catalog** (D2's catalog
+of choice points, D4's declared classes per point). That catalog enumerates the
+outcomes of a *choice* — things that happen, each with a name. D1 says
+unwinnability is the absence of a reachable ending, which is a property of a
+**state**, not an outcome of a choice; a point has no class for it to occupy.
+
+It is reported by the **coverage surface** — ADR-293 D15, "coverage is the
+author-facing answer" — alongside ADR-302 D6's untaken divergences, where the
+unit is already "a place the story can be in that nothing tests." D15 is an
+aggregation over D16's trace stream rather than a bespoke format, so a second
+kind of finding is a new consumer of an existing producer, not a new pipeline.
+
+> **CITATION CORRECTED 2026-08-05, same session, by `adr-review`.** This
+> decision first read "not in ADR-293 D15's outcome-class registry… it belongs
+> to the coverage surface", which is self-contradictory: D15 **is** the coverage
+> surface. The catalog is D2/D4. The ruling was never in doubt — the citation
+> inverted it, and three sites carried the error.
+
+**The three layers, all three wanted:**
+
+- **Declared invariants — the assertion.** The author names what must stay
+  true (*the deed must remain gettable*), and the harness checks the predicate
+  per turn. The only layer that can assert something true, and it catches
+  exactly what the author thought to name.
+- **Irreversibility flags — the candidate set.** Report every action that
+  *reduces* reachability: an item consumed, a one-way exit taken, a door shut
+  for good. Needs no author input and has false positives by design, which is
+  correct for a surface whose job is to raise candidates rather than deliver
+  verdicts. This is the layer that finds what nobody thought to name.
+- **Probing — the detector**, in two modes (below).
+
+**Probing does not search for a win; it replays a known one.** Full reachability
+is exponential and is not attempted. But a finished story already carries its
+answer key — Fernhill's `the-long-night`, Dungeo's 17-file chain — so the probe
+from a state S is: *replay the remaining suffix of the known winning path; if it
+still wins, S is winnable.* That is **one walkthrough per probe**, not a search,
+and it is necessary-but-not-sufficient: a failed replay may mean the route
+changed rather than the win being gone, which is why the output is a candidate
+and not a verdict.
+
+- **Routine mode** seeds from the states the suite already reaches — every
+  end-branch is a probe point. Fernhill: 19 leaves × the win suffix ≈ 1000
+  commands, under a second at the measured 10²–10³ commands/sec.
+- **Deep mode** BFSes the reachable space, dedupes by state signature, and
+  probes the frontier, parallelized across cores. Hours, not seconds; run
+  deliberately, never as a gate (there are no CI gates in this project).
+
+**Parallelism is free here because of D17.** With no save/restore in the walk, a
+worker boots and replays a path and shares nothing with its siblings — which is
+what ADR-302 D10 already claims the tree permits.
+
+**The shared primitive: a semantic world-state signature.** Deduping states in
+deep mode needs a canonical signature, and the obvious candidate — the ADR-293
+save payload — carries turn counters and RNG stream states that differ for
+irrelevant reasons. A signature that ignores them is required. **D4 needs the
+same primitive**: "does this variant arrive where its sibling arrives, on the
+entities the author named" is the same operation as "have I seen this state
+before." Build it once; it serves both, and neither should invent its own.
+
+**Pilot corpus: Fernhill first, Dungeo as the stress test.** Dungeo is the
+richer hunting ground — it mirrors MDL Dungeon, which is merciless, and it has
+a 952-command answer key. But it is also the most stochastic corpus here: the
+thief and combat mean a suffix replayed from a shifted state fails for RNG
+reasons rather than unwinnable ones, and a pilot there would be spent debugging
+false positives. Fernhill is deterministic at a pinned seed and fast, so it
+proves the mechanism; Dungeo then stresses it, with ADR-293 `forces:` pinning
+the stochastic points so a suffix failure means what it says. **This uses Dungeo
+as a measurement target, which D9 permits — it forbids letting Dungeo's corpus
+shape a design, not pointing a finished tool at it.**
+
+**D6 — ADR-131's explorer is widened, not replaced, and the static analysis
+moves to the IDE.** (Resolves Q-3, session f2a7e6, David's call.)
+
+**One explorer, two modes.** ADR-131 gains reachability probing (D5) alongside
+the regression baseline it already describes. They share the walk and differ in
+everything else — the baseline records prose and is diffed often, the probe
+yields candidate states and is run rarely — so a mode is the right seam, not a
+second tool.
+
+**Its stated exclusion survives the widening, which is why this extends ADR-131
+rather than replacing it.** ADR-131 says it *"avoids the hard problem of
+puzzle-solving and focuses on regression coverage."* D5's probe solves nothing:
+it replays an answer key the finished story already ships. The excluded thing
+and the added thing are not the same thing. An earlier draft of this ADR argued
+the opposite — that widening would "replace its premise rather than extend it" —
+and that objection is retracted here rather than deleted, because it was
+load-bearing in the question it answered.
+
+**The static half moves to the IDE.** `tools/vscode-ext/src/world-explorer.ts`
+already computes the graph-computable portion — dead ends and one-way exits from
+`--world-json` — the cheap layer of this idea living in the wrong product. It
+moves rather than being mirrored: two copies of a reachability analysis will
+eventually disagree, and the disagreement would be discovered by an author.
+
+*Flip owner and trigger:* **whoever accepts this ADR** amends ADR-131 in the
+same commit as the acceptance — replacing its "SCOPE QUESTION OPENED" note with
+the widening recorded here, and stating the two modes in its Decision. The
+trigger is acceptance of this ADR; the owner is the accepter, not a later
+reader. ADR-131 stands unamended until that lands. This ADR does not edit
+ADR-131 itself: one writer per artifact, and an interview writes only the ADR
+under interview.
+
+---
+
+## Consequences
+
+**D4 gives the tree a second edge kind, and the cost lands in three places.**
+`converges-with` is an assertion between siblings, not a parent pointer, so the
+forest invariant survives it untouched. The opt-in multi-parent form does not:
+tree assembly must expand a node with N parents into N runs, the report must
+name a node once per run without double-counting it as a failure, and the IDE's
+column view must show the same stem under several routes without implying it is
+several tests. None of that is hard; all of it must be decided together, because
+a half-expanded tree reports numbers nobody can reconcile.
+
+**Convergence assertions need somewhere to read state from.** D17 removed
+save/restore from the tree walk, so the harness no longer has a serialized world
+in hand at a node boundary. Comparing two variants' named entities needs a read
+path that does not reintroduce the save hooks that issue #229 was about.
+
+**ADR-302 stays ACCEPTED and shipped.** These questions are raised *by* its
+usage, not left unresolved *within* it: D1's one-parent rule works, is
+implemented, and is merged. Nothing here reopens it.
+
+**D6 gets its first concrete content.** "The same state is reachable three ways
+and only one route is tested" and "this branch leads somewhere the story cannot
+be finished from" are both untaken-divergence coverage facts. Whatever
+implements D6 should be designed against these two cases rather than against
+the abstraction.
+
+---
+
+## Session
+
+Raised in session f2a7e6 (2026-08-05, branch
+`feat/adr-300-302-channels-branch-tester`) while mocking the IDE Testing tab
+against Fernhill's real tree. The layout study forced the shape question — the
+real suite is wide and shallow, 12 children off one node — and David's two
+observations followed from looking at it: that an open world reconverges, and
+that an unwinnable state belongs in the divergence surface with the explorer
+as a possible host.
+
+The distinctions in the Decision section are his framing; the survey of what
+ADR-131 and the VS Code world-explorer actually do, and the tractability
+analysis in Q-2, were done in-session against the source rather than recalled.

--- a/docs/context/session-20260805-1707-feat-adr-300-302-channels-branch-tester.md
+++ b/docs/context/session-20260805-1707-feat-adr-300-302-channels-branch-tester.md
@@ -111,6 +111,61 @@ the engine merge while the tree walk was the collision's only victim, which the
 four-caller survey disproved. D17 itself stands — re-execution was chosen on its own
 terms, and the engine fix closes callers D17 never reached.
 
+### 6. ADR-303 written and interviewed to resolution
+Two gaps David raised while reviewing the IDE Testing mocks, neither considered by
+ADR-302: open-world paths **reconverge** ("do one of three things, then go to a
+room"), and an **unwinnable state is not a losing ending** — it has no ending, no
+message and no test, which is why it ships.
+
+Written as a **new** ADR rather than reopening ADR-302, which stays ACCEPTED: these
+are questions raised *by* its usage, not left unresolved *within* it. All three open
+questions were then resolved by interview the same session:
+
+- **D4** — a converging variant declares `converges-with:` and the harness *verifies*
+  it before a shared tail runs once; what must match is author-named. Re-running the
+  tail under every route is a per-fork opt-in, expressed as several parents and
+  **expanded to N single-ancestry runs** so every ADR-302 invariant holds per run.
+  `converges-with` does **not** inherit — declared-only, the same keying `reseedFor`
+  uses, because inheritance is right for a setting and wrong for an instruction.
+- **D5** — three detection layers (declared invariants, irreversibility flags,
+  probing). Probing replays the story's own answer key rather than searching: one
+  walkthrough per probe, not an exponential search. Fernhill's 19 leaves ≈ 1000
+  commands, under a second. Deep parallel mode on demand. Unwinnable is reported by
+  the coverage surface and stays out of the point-and-class catalog.
+- **D6** — ADR-131's explorer is widened rather than replaced (its "avoids
+  puzzle-solving" exclusion survives, because replaying an answer key solves
+  nothing), and the static dead-end/one-way analysis moves from the VS Code
+  extension to the IDE.
+
+**A shared primitive fell out of it**: D4's "does this variant arrive where its
+sibling arrives" and D5's "have I seen this state before" are the same operation —
+a semantic world-state signature that ignores turn counters and RNG streams. Built
+once, it serves both.
+
+`adr-review` then scored it **7/17, NEEDS WORK**, and caught two citation failures
+worth recording: ADR-293 **D15 is the coverage report, not a registry** (the catalog
+is D2/D4), which made D5's central sentence self-contradictory; and **Miller columns
+were attributed to ADR-301**, which is TBD and specifies no surface — the design came
+from this session's mocks. Both corrected in place with dated notes, along with a
+D8 inheritance gap and a D1 heading that contradicted D5 once the citation was fixed.
+The ADR stays **DRAFT**: no acceptance criteria, no test requirements, no
+implementation section, and three interfaces still undefined.
+
+### 7. IDE Testing mocks (artifacts, not committed)
+Two published artifacts — a Testing-tab mock and a layout study — built on the
+shell's own Catppuccin tokens from `Theme.swift`. The layout study measured the
+real 22-node tree in three layouts and killed the horizontal canvas: vertical extent
+tracks leaf count, not depth, so a depth-3 tree costs ~800px, and lineage colour
+would need 12 hues for one fan-out. David's call was Miller columns (Finder), which
+makes ancestry spatial and needs no palette. A run-folding idea for deep chains was
+built at his request and then removed at his request — it was the one departure from
+Finder and hid nodes behind a summary.
+
+Surveyed rather than assumed: `TestPanelView` is **already** an `NSOutlineView`
+whose data source is two levels deep (entries → their commands), so click-to-expand
+turns exists today. What is missing is a level *above* it — entry-to-entry
+parentage — plus `.unreached` on `Status`, and a wire that carries any of it.
+
 ---
 
 ## Session Metadata

--- a/docs/context/session-20260805-1707-feat-adr-300-302-channels-branch-tester.md
+++ b/docs/context/session-20260805-1707-feat-adr-300-302-channels-branch-tester.md
@@ -81,6 +81,36 @@ Claimed in conversation that D17 would remove it; that was wrong and is correcte
 
 **A second copy bit twice.** `freshGameForRoot` exists in both `packages/branch-tester/src/cli.ts` and `scripts/bundle-entry.js`. Updating only the first left the bundle throwing `Cannot read properties of undefined (reading 'transcript')` on the first fork. The bundle copy also revealed a real hazard the package copy shared: a re-boot must re-pin the seed the root *actually* booted with, or a root with no `seed:` would draw a fresh clock seed per boot and its replayed prefix would diverge. Both now remember it. This did not bite Fernhill only because every root had already been given an explicit seed in §1.
 
+### 5. Closed the latent form at the engine (issue #229), after the merge
+Filed #229 for the general form of #227 — `registerSaveRestoreHooks` assigning
+wholesale, so any caller silently disables restart — then, on David's call, fixed it.
+
+A survey found **four** remaining callers, not two: the ADR-300 D18 divergence save
+and the `$save`/`$restore` directives in each harness's `runner.ts`, plus
+`searchOutcome`'s per-candidate restore in each `search.ts`. v1 is closer to the
+trigger than v2, because a chain shares one live engine across files — a blessed
+golden on any member plus a `restart` in a later member arms it. Confirmed not live:
+`grep -ln "^> restart" stories/dungeo/walkthroughs/*.transcript` is empty.
+
+The engine now merges: named entries replace, unnamed survive, removal is spelled by
+naming an entry `undefined`. `save()`/`restore()` guard on the specific hook they need
+rather than on "some hooks exist", so a partial registration reports "no capability"
+instead of calling `undefined` and reporting the TypeError as a failure. Bootstrap's
+`as any` cast is gone — partial registration is now expressible.
+
+**A second consequence, under-called before it showed as red tests:** merging
+necessarily **snapshots**. The engine holds a copy, so mutating a registered hooks
+object no longer reaches it. Eight `platform-operations.test.ts` cases relied on
+exactly that aliasing, and two more used `registerSaveRestoreHooks({})` to mean
+"clear", which merging makes a no-op. The source-caller survey that preceded the
+change looked for reliance on replacement and correctly found none — it never looked
+at tests, and that is where it lived. Recorded in the method's contract doc.
+
+ADR-302 D17's rejected-alternatives paragraph is amended in place: it argued against
+the engine merge while the tree walk was the collision's only victim, which the
+four-caller survey disproved. D17 itself stands — re-execution was chosen on its own
+terms, and the engine fix closes callers D17 never reached.
+
 ---
 
 ## Session Metadata

--- a/packages/bootstrap/src/assemble-restart.test.ts
+++ b/packages/bootstrap/src/assemble-restart.test.ts
@@ -104,6 +104,45 @@ describe('ADR-248 assembleGame restart reboot', () => {
     expect(banner.title).toBe(second.story.config.title);
   });
 
+  it('#227 — a runner registering save/restore hooks does not disable the reboot', async () => {
+    // The real path for issue #227, end to end: bootstrap registers
+    // onRestartRequested at boot, a harness then registers its own save and
+    // restore hooks on the same engine, and the reboot must still fire. Before
+    // the #229 merge fix, the second registration replaced the hook object,
+    // `shouldRestart` defaulted to true, and the engine acked and stopped
+    // without ever rebooting — leaving every later command dead.
+    const first = makeStory();
+    const second = makeStory();
+    let freshCalls = 0;
+
+    const game = assembleGame(first.story, {
+      freshStory: () => {
+        freshCalls += 1;
+        return second.story;
+      },
+    });
+
+    let captured: unknown = null;
+    game.engine.registerSaveRestoreHooks({
+      onSaveRequested: async (data: unknown) => { captured = data; },
+      onRestoreRequested: async () => null,
+    });
+
+    // The harness's own hooks work — merging did not cost it its registration.
+    await expect(game.engine.save()).resolves.toBe(true);
+    expect(captured).not.toBeNull();
+
+    const output = await game.executeCommand('restart');
+    expect(output).toContain('The story restarts.');
+    expect(freshCalls).toBe(1);
+
+    // The engine is alive on the other side. This is the assertion that failed
+    // as "Error: Engine is not running" for every node with a parent.
+    const look = await game.executeCommand('look');
+    expect(look).toContain('Test Chamber');
+    expect(look).not.toContain('Engine is not running');
+  });
+
   it('without a freshStory provider, a confirmed restart surfaces an honest error', async () => {
     const { story } = makeStory();
     const game = assembleGame(story);

--- a/packages/bootstrap/src/index.ts
+++ b/packages/bootstrap/src/index.ts
@@ -236,12 +236,14 @@ export function assembleGame(
 
     // ADR-248: auto-confirm restart (the harness has no player to ask) and
     // defer the reboot until the restart turn's output has been captured.
+    // Registration merges (#229), so this survives a runner registering its
+    // own save/restore hooks later — which is exactly what used to destroy it.
     engine.registerSaveRestoreHooks({
       onRestartRequested: async (): Promise<boolean> => {
         pendingReboot = true;
         return true;
       },
-    } as any);
+    });
 
     // Start the channel-I/O pipeline (ADR-163). The engine builds its
     // ChannelService internally from these capabilities during start().

--- a/packages/branch-tester/src/runner.ts
+++ b/packages/branch-tester/src/runner.ts
@@ -73,9 +73,16 @@ interface GameEngine {
    * session's master seed from here (ADR-294 D3).
    */
   engine?: {
+    /**
+     * Registration MERGES on the real engine and every hook is optional
+     * (issue #229), so this declares the loosest shape that still says what
+     * the tester uses. It compiles either way here — this seam passes through
+     * a cast — but the declaration was making a claim about the engine that
+     * stopped being true, and v1 broke on exactly that.
+     */
     registerSaveRestoreHooks(hooks: {
-      onSaveRequested(data: unknown): Promise<void>;
-      onRestoreRequested(): Promise<unknown | null>;
+      onSaveRequested?(data: any): Promise<void>;
+      onRestoreRequested?(): Promise<any>;
     }): void;
     save(): Promise<boolean>;
     restore(): Promise<boolean>;

--- a/packages/engine/src/game-engine.ts
+++ b/packages/engine/src/game-engine.ts
@@ -160,7 +160,8 @@ export class GameEngine {
   private languageProvider?: LanguageProvider;
   private parser?: Parser;
   private eventListeners = new Map<GameEngineEventName, Set<(...args: any[]) => void>>();
-  private saveRestoreHooks?: ISaveRestoreHooks;
+  /** Accumulated across every `registerSaveRestoreHooks` call, hence Partial. */
+  private saveRestoreHooks?: Partial<ISaveRestoreHooks>;
   private eventSource = createSemanticEventSource();
   private systemEventSource: IGenericEventSource<ISystemEvent>;
   private pendingPlatformOps: IPlatformEvent[] = [];
@@ -1994,16 +1995,43 @@ export class GameEngine {
   }
 
   /**
-   * Register save/restore hooks
+   * Register save/restore hooks, MERGING them into whatever is already
+   * registered (issue #229).
+   *
+   * The four hooks are one object but four unrelated concerns: two clients
+   * legitimately own different ones. A harness owns `onRestartRequested`
+   * (auto-confirming a restart nobody is present to approve) while a test
+   * runner or bridge owns `onSaveRequested`/`onRestoreRequested`. Assigning
+   * wholesale — which this did until 2026-08-05 — meant the second registrant
+   * silently destroyed the first's, and the failure was invisible: with
+   * `onRestartRequested` gone, `shouldRestart` defaults to true, so `restart`
+   * still acked and stopped the engine while the reboot that ack promised
+   * never fired (issue #227). Merging makes partial registration the supported
+   * shape rather than a trap.
+   *
+   * A named entry replaces the prior one of that name; entries the caller does
+   * not name are left alone. To REMOVE a hook, name it explicitly as
+   * `undefined` — every read site treats an absent and an undefined entry the
+   * same way. `{}` therefore registers nothing rather than clearing everything.
+   *
+   * **This SNAPSHOTS.** Merging necessarily copies, so the engine no longer
+   * holds the caller's object: mutating a hooks object after registering it
+   * has no effect, where it used to reach the engine through the shared
+   * reference. Re-register to change a hook.
+   *
+   * @param hooks any subset of the four hooks
    */
-  registerSaveRestoreHooks(hooks: ISaveRestoreHooks): void {
-    this.saveRestoreHooks = hooks;
+  registerSaveRestoreHooks(hooks: Partial<ISaveRestoreHooks>): void {
+    this.saveRestoreHooks = { ...this.saveRestoreHooks, ...hooks };
   }
 
   /**
-   * Get currently registered save/restore hooks
+   * Get currently registered save/restore hooks.
+   *
+   * Partial because registration is (see above): what comes back is the
+   * accumulation of every registration so far, which need not carry all four.
    */
-  getSaveRestoreHooks(): ISaveRestoreHooks | undefined {
+  getSaveRestoreHooks(): Partial<ISaveRestoreHooks> | undefined {
     return this.saveRestoreHooks;
   }
 
@@ -2045,7 +2073,12 @@ export class GameEngine {
    * Save game state using registered hooks
    */
   async save(): Promise<boolean> {
-    if (!this.saveRestoreHooks) {
+    // Guarded on the hook this needs, not merely on some hooks existing:
+    // registration is partial (#229), so a client that registered only
+    // `onRestartRequested` leaves this one absent. Calling it would throw a
+    // TypeError into the catch below and report as "Save failed"; saying
+    // "no save capability" is the honest answer.
+    if (!this.saveRestoreHooks?.onSaveRequested) {
       return false; // No save capability
     }
 
@@ -2063,7 +2096,8 @@ export class GameEngine {
    * Restore game state using registered hooks
    */
   async restore(): Promise<boolean> {
-    if (!this.saveRestoreHooks) {
+    // Guarded on the specific hook, for the reason given in `save()`.
+    if (!this.saveRestoreHooks?.onRestoreRequested) {
       return false; // No restore capability
     }
 

--- a/packages/engine/tests/platform-operations.test.ts
+++ b/packages/engine/tests/platform-operations.test.ts
@@ -27,6 +27,18 @@ import {
 import { MinimalTestStory } from './stories';
 import { setupTestEngine } from './test-helpers/setup-test-engine';
 
+/**
+ * Removing every hook. Registration MERGES (#229), so `{}` is a no-op and a
+ * test that means "nothing is registered" has to say which entries it is
+ * dropping — every read site treats absent and undefined alike.
+ */
+const NO_HOOKS = {
+  onSaveRequested: undefined,
+  onRestoreRequested: undefined,
+  onQuitRequested: undefined,
+  onRestartRequested: undefined
+};
+
 describe('GameEngine Platform Operations', () => {
   let engine: GameEngine;
   let story: MinimalTestStory;
@@ -123,6 +135,7 @@ describe('GameEngine Platform Operations', () => {
 
     it('should emit save failed event when hook throws', async () => {
       mockHooks.onSaveRequested = vi.fn().mockRejectedValue(new Error('Save failed'));
+      engine.registerSaveRestoreHooks(mockHooks);
       
       const events: any[] = [];
       engine.on('event', (event) => events.push(event));
@@ -141,7 +154,7 @@ describe('GameEngine Platform Operations', () => {
     });
 
     it('should emit save failed event when no save hook registered', async () => {
-      engine.registerSaveRestoreHooks({});
+      engine.registerSaveRestoreHooks(NO_HOOKS);
       
       const events: any[] = [];
       engine.on('event', (event) => events.push(event));
@@ -187,6 +200,8 @@ describe('GameEngine Platform Operations', () => {
       ).createSaveData();
 
       mockHooks.onRestoreRequested = vi.fn().mockResolvedValue(mockSaveData);
+
+      engine.registerSaveRestoreHooks(mockHooks);
       
       const events: any[] = [];
       engine.on('event', (event) => events.push(event));
@@ -203,6 +218,7 @@ describe('GameEngine Platform Operations', () => {
 
     it('should emit restore failed event when no save data available', async () => {
       mockHooks.onRestoreRequested = vi.fn().mockResolvedValue(null);
+      engine.registerSaveRestoreHooks(mockHooks);
       
       const events: any[] = [];
       engine.on('event', (event) => events.push(event));
@@ -255,6 +271,7 @@ describe('GameEngine Platform Operations', () => {
 
     it('should emit cancelled event when quit declined', async () => {
       mockHooks.onQuitRequested = vi.fn().mockResolvedValue(false);
+      engine.registerSaveRestoreHooks(mockHooks);
       
       const events: any[] = [];
       engine.on('event', (event) => events.push(event));
@@ -270,7 +287,7 @@ describe('GameEngine Platform Operations', () => {
     });
 
     it('should quit by default when no hook registered', async () => {
-      engine.registerSaveRestoreHooks({});
+      engine.registerSaveRestoreHooks(NO_HOOKS);
       
       const events: any[] = [];
       engine.on('event', (event) => events.push(event));
@@ -343,6 +360,7 @@ describe('GameEngine Platform Operations', () => {
 
     it('should emit cancelled event and keep running when restart declined', async () => {
       mockHooks.onRestartRequested = vi.fn().mockResolvedValue(false);
+      engine.registerSaveRestoreHooks(mockHooks);
 
       const events: any[] = [];
       engine.on('event', (event) => events.push(event));
@@ -379,6 +397,7 @@ describe('GameEngine Platform Operations', () => {
 
     it('meta path: declined restart returns restart_cancelled and keeps the engine running', async () => {
       mockHooks.onRestartRequested = vi.fn().mockResolvedValue(false);
+      engine.registerSaveRestoreHooks(mockHooks);
 
       const restartEvent = createRestartRequestedEvent({ reason: 'user_requested' });
 
@@ -405,6 +424,7 @@ describe('GameEngine Platform Operations', () => {
         callOrder.push('restore');
         return null;
       });
+      engine.registerSaveRestoreHooks(mockHooks);
       
       const saveEvent = createSaveRequestedEvent({ saveName: 'test', timestamp: Date.now() });
       const restoreEvent = createRestoreRequestedEvent({ saveName: 'test' });
@@ -419,7 +439,9 @@ describe('GameEngine Platform Operations', () => {
 
     it('should continue processing even if one operation fails', async () => {
       mockHooks.onSaveRequested = vi.fn().mockRejectedValue(new Error('Save failed'));
+      engine.registerSaveRestoreHooks(mockHooks);
       mockHooks.onRestoreRequested = vi.fn().mockResolvedValue(null);
+      engine.registerSaveRestoreHooks(mockHooks);
       
       const saveEvent = createSaveRequestedEvent({ saveName: 'test', timestamp: Date.now() });
       const restoreEvent = createRestoreRequestedEvent({ saveName: 'test' });

--- a/packages/engine/tests/save-restore-hooks-merge.test.ts
+++ b/packages/engine/tests/save-restore-hooks-merge.test.ts
@@ -1,0 +1,112 @@
+/**
+ * save-restore-hooks-merge.test.ts — registration merges (issue #229).
+ *
+ * Derived from the `registerSaveRestoreHooks` Behavior Statement: a named entry
+ * replaces the prior one of that name, entries the caller did not name survive,
+ * and `save()`/`restore()` answer honestly when the hook they need is absent.
+ *
+ * The defect this pins is not "hooks were lost" in the abstract. The four hooks
+ * are one object but four unrelated concerns, and two clients legitimately own
+ * different ones — a harness owns `onRestartRequested`, a runner owns
+ * save/restore. Wholesale assignment made the second registrant destroy the
+ * first's silently, and with `onRestartRequested` gone the engine defaulted
+ * `shouldRestart` to true: `restart` acked, stopped the engine, and never
+ * rebooted (#227). The last case below is that exact sequence.
+ *
+ * Owner context: engine test suite (platform).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { setupTestEngine } from './test-helpers/setup-test-engine';
+
+describe('registerSaveRestoreHooks merges (#229)', () => {
+  it('keeps an entry a later registration did not name', () => {
+    const { engine } = setupTestEngine();
+    const onRestartRequested = vi.fn(async () => true);
+
+    engine.registerSaveRestoreHooks({ onRestartRequested });
+    engine.registerSaveRestoreHooks({
+      onSaveRequested: async () => {},
+      onRestoreRequested: async () => null,
+    });
+
+    // The harness's restart hook survives the runner's save/restore
+    // registration. Before #229 this was undefined.
+    expect(engine.getSaveRestoreHooks()?.onRestartRequested).toBe(onRestartRequested);
+    expect(engine.getSaveRestoreHooks()?.onSaveRequested).toBeDefined();
+  });
+
+  it('replaces an entry a later registration DOES name', () => {
+    const { engine } = setupTestEngine();
+    const first = vi.fn(async () => null);
+    const second = vi.fn(async () => null);
+
+    engine.registerSaveRestoreHooks({ onRestoreRequested: first });
+    engine.registerSaveRestoreHooks({ onRestoreRequested: second });
+
+    expect(engine.getSaveRestoreHooks()?.onRestoreRequested).toBe(second);
+  });
+
+  it('removes an entry named explicitly as undefined', () => {
+    // Merging would otherwise make a hook unremovable. Naming it is the escape
+    // hatch, and every read site treats absent and undefined alike.
+    const { engine } = setupTestEngine();
+    engine.registerSaveRestoreHooks({ onQuitRequested: async () => true });
+    engine.registerSaveRestoreHooks({ onQuitRequested: undefined });
+
+    expect(engine.getSaveRestoreHooks()?.onQuitRequested).toBeUndefined();
+  });
+
+  it('save() reports no capability when only unrelated hooks are registered', async () => {
+    // Partial registration is now the supported shape, so `save()` must answer
+    // for the hook it needs rather than calling `undefined` and reporting the
+    // resulting TypeError as "Save failed".
+    const { engine } = setupTestEngine();
+    engine.registerSaveRestoreHooks({ onRestartRequested: async () => true });
+
+    await expect(engine.save()).resolves.toBe(false);
+  });
+
+  it('restore() reports no capability when only unrelated hooks are registered', async () => {
+    const { engine } = setupTestEngine();
+    engine.registerSaveRestoreHooks({ onRestartRequested: async () => true });
+
+    await expect(engine.restore()).resolves.toBe(false);
+  });
+
+  it('save() runs once the hook it needs is merged in', async () => {
+    const { engine } = setupTestEngine();
+    const onSaveRequested = vi.fn(async () => {});
+
+    engine.registerSaveRestoreHooks({ onRestartRequested: async () => true });
+    engine.registerSaveRestoreHooks({ onSaveRequested, onRestoreRequested: async () => null });
+    engine.start();
+
+    await expect(engine.save()).resolves.toBe(true);
+    expect(onSaveRequested).toHaveBeenCalledOnce();
+  });
+
+  it('#227 — a runner registering save hooks leaves restart confirmation intact', async () => {
+    // The original defect, at the layer that caused it: the confirmation hook
+    // is still consulted after an unrelated registration, so a client that
+    // wants to defer or refuse a restart still gets the chance.
+    const { engine } = setupTestEngine();
+    const onRestartRequested = vi.fn(async () => false);
+
+    engine.registerSaveRestoreHooks({ onRestartRequested });
+    engine.registerSaveRestoreHooks({
+      onSaveRequested: async () => {},
+      onRestoreRequested: async () => null,
+    });
+    engine.start();
+
+    await engine.executeTurn('restart');
+
+    expect(onRestartRequested).toHaveBeenCalledOnce();
+    // It refused, so the engine is still running. That is the observable proof
+    // the hook was consulted rather than defaulted past: a defaulted-true
+    // restart calls stop(), and the next turn would throw "Engine is not
+    // running" instead of resolving.
+    await expect(engine.executeTurn('look')).resolves.toBeDefined();
+  });
+});

--- a/packages/sharpee/docs/genai-api/engine.md
+++ b/packages/sharpee/docs/genai-api/engine.md
@@ -1244,6 +1244,7 @@ export declare class GameEngine {
     private languageProvider?;
     private parser?;
     private eventListeners;
+    /** Accumulated across every `registerSaveRestoreHooks` call, hence Partial. */
     private saveRestoreHooks?;
     private eventSource;
     private systemEventSource;
@@ -1584,13 +1585,35 @@ export declare class GameEngine {
      */
     registerSlotEntry(entry: SlotEntry): void;
     /**
-     * Register save/restore hooks
+     * Register save/restore hooks, MERGING them into whatever is already
+     * registered (issue #229).
+     *
+     * The four hooks are one object but four unrelated concerns: two clients
+     * legitimately own different ones. A harness owns `onRestartRequested`
+     * (auto-confirming a restart nobody is present to approve) while a test
+     * runner or bridge owns `onSaveRequested`/`onRestoreRequested`. Assigning
+     * wholesale — which this did until 2026-08-05 — meant the second registrant
+     * silently destroyed the first's, and the failure was invisible: with
+     * `onRestartRequested` gone, `shouldRestart` defaults to true, so `restart`
+     * still acked and stopped the engine while the reboot that ack promised
+     * never fired (issue #227). Merging makes partial registration the supported
+     * shape rather than a trap.
+     *
+     * A named entry replaces the prior one of that name; entries the caller does
+     * not name are left alone. To REMOVE a hook, name it explicitly as
+     * `undefined` — every read site treats an absent and an undefined entry the
+     * same way.
+     *
+     * @param hooks any subset of the four hooks
      */
-    registerSaveRestoreHooks(hooks: ISaveRestoreHooks): void;
+    registerSaveRestoreHooks(hooks: Partial<ISaveRestoreHooks>): void;
     /**
-     * Get currently registered save/restore hooks
+     * Get currently registered save/restore hooks.
+     *
+     * Partial because registration is (see above): what comes back is the
+     * accumulation of every registration so far, which need not carry all four.
      */
-    getSaveRestoreHooks(): ISaveRestoreHooks | undefined;
+    getSaveRestoreHooks(): Partial<ISaveRestoreHooks> | undefined;
     /**
      * Register a transformer for parsed commands.
      * Transformers are called after parsing but before validation,

--- a/packages/sharpee/docs/genai-api/index.md
+++ b/packages/sharpee/docs/genai-api/index.md
@@ -29,7 +29,7 @@ Generated for Sharpee 4.4.0
 | [core.md](core.md) | @sharpee/core | Base types, query system, platform events, entity interfaces, debug utilities. (30 files, ~2725 lines) |
 | [if-domain.md](if-domain.md) | @sharpee/if-domain | Domain events, contracts, grammar system, language/parser provider interfaces. (23 files, ~3520 lines) |
 | [world-model.md](world-model.md) | @sharpee/world-model | Entity system (IFEntity), WorldModel, all traits, capability dispatch, scope, annotations. (121 files, ~9568 lines) |
-| [engine.md](engine.md) | @sharpee/engine | GameEngine, Story interface, turn cycle, command executor, save/restore, vocabulary. (39 files, ~3720 lines) |
+| [engine.md](engine.md) | @sharpee/engine | GameEngine, Story interface, turn cycle, command executor, save/restore, vocabulary. (39 files, ~3743 lines) |
 | [stdlib.md](stdlib.md) | @sharpee/stdlib | All 43 standard actions, validation, scope builders, NPC support, combat, action chains. (47 files, ~4608 lines) |
 | [parser.md](parser.md) | @sharpee/parser-en-us | English parser, grammar patterns, story grammar extension API. (4 files, ~438 lines) |
 | [lang.md](lang.md) | @sharpee/lang-en-us | English language provider, message resolution, formatters. (17 files, ~2677 lines) |
@@ -41,4 +41,4 @@ Generated for Sharpee 4.4.0
 | [character.md](character.md) | @sharpee/character | NPC/character authoring — builders, applyCharacter, character model. (31 files, ~3135 lines) |
 | [authoring.md](authoring.md) | Authoring Helpers | Fluent entity-builder DSL (helpers) and the EntityQuery API (queries). (7 files, ~792 lines) |
 | [presentation.md](presentation.md) | Presentation | Browser web client, channel renderers, and media/audio. (25 files, ~2500 lines) |
-| [tooling.md](tooling.md) | Tooling | Build/CLI orchestration (devkit) and the transcript test engine. (17 files, ~1459 lines) |
+| [tooling.md](tooling.md) | Tooling | Build/CLI orchestration (devkit) and the transcript test engine. (17 files, ~1467 lines) |

--- a/packages/sharpee/docs/genai-api/tooling.md
+++ b/packages/sharpee/docs/genai-api/tooling.md
@@ -958,9 +958,17 @@ interface GameEngine {
      * session's master seed from here (ADR-294 D3).
      */
     engine?: {
+        /**
+         * Registration MERGES on the real engine and every hook is optional
+         * (issue #229), so this declares the loosest shape that still says what
+         * the tester uses. Naming both as required — which it did until
+         * 2026-08-05 — made the real `(hooks: Partial<ISaveRestoreHooks>) => void`
+         * unassignable to it in both directions, since `unknown` is not an
+         * `ISaveData` and a required member is not a `Partial` one.
+         */
         registerSaveRestoreHooks(hooks: {
-            onSaveRequested(data: unknown): Promise<void>;
-            onRestoreRequested(): Promise<unknown | null>;
+            onSaveRequested?(data: any): Promise<void>;
+            onRestoreRequested?(): Promise<any>;
         }): void;
         save(): Promise<boolean>;
         restore(): Promise<boolean>;

--- a/packages/transcript-tester/src/runner.ts
+++ b/packages/transcript-tester/src/runner.ts
@@ -65,9 +65,17 @@ interface GameEngine {
    * session's master seed from here (ADR-294 D3).
    */
   engine?: {
+    /**
+     * Registration MERGES on the real engine and every hook is optional
+     * (issue #229), so this declares the loosest shape that still says what
+     * the tester uses. Naming both as required — which it did until
+     * 2026-08-05 — made the real `(hooks: Partial<ISaveRestoreHooks>) => void`
+     * unassignable to it in both directions, since `unknown` is not an
+     * `ISaveData` and a required member is not a `Partial` one.
+     */
     registerSaveRestoreHooks(hooks: {
-      onSaveRequested(data: unknown): Promise<void>;
-      onRestoreRequested(): Promise<unknown | null>;
+      onSaveRequested?(data: any): Promise<void>;
+      onRestoreRequested?(): Promise<any>;
     }): void;
     save(): Promise<boolean>;
     restore(): Promise<boolean>;


### PR DESCRIPTION
Follow-on to #228, which merged earlier today. Two commits: an engine fix that closes #229, and a new ADR resolved by interview.

## `fix(engine)` — registerSaveRestoreHooks merges instead of replacing

The general form of #227. The engine assigned its **whole** hook object on every registration, and restart confirmation lives on that same object as `onRestartRequested` — so any caller registering save/restore hooks silently disabled `restart` for the rest of that engine's life. The ack still rendered and the engine still stopped; only the reboot went missing.

ADR-302 D17 removed the caller that made it reachable. A survey found **four more**, none being deleted — the D18 divergence save and the `$save`/`$restore` directives in each harness's `runner.ts`, plus `searchOutcome`'s per-candidate restore in each `search.ts`. v1 sits closer to the trigger than v2: a chain shares one live engine across files, so a blessed golden on any member plus a `restart` in a *later* member arms it.

Registration now merges — named entries replace, unnamed survive, removal is spelled by naming an entry `undefined`. `save()`/`restore()` guard on the specific hook they need rather than on "some hooks exist", so a partial registration reports "no save capability" instead of calling `undefined` and reporting the TypeError as a failure.

**Merging necessarily snapshots**, and that is a contract change: the engine holds a copy, so mutating a hooks object after registering it no longer reaches it. Eight `platform-operations` tests relied on exactly that aliasing and two more used `{}` as a clear. The survey that preceded the change looked for *source* callers relying on replacement and correctly found none — it never looked at the tests, which is where the reliance lived. Documented on the method.

## `docs(adr-303)` — convergent paths and unwinnable states

Two gaps ADR-302 never considered, raised while reviewing the IDE Testing surface against Fernhill's real tree:

- **Open world means paths reconverge.** A fork that rejoins has no expression today beyond duplicating its tail or hanging it off one variant.
- **An unwinnable state is not a losing ending.** It has no ending, no message and no test, which is why it ships.

Written as a **new ADR**; ADR-302 stays ACCEPTED, since these are questions raised *by* its usage rather than left unresolved *within* it. All three open questions were then resolved by interview:

- **D4** — `converges-with:` is declared and *verified* before a shared tail runs once; author-named subset; re-running per route is a per-fork opt-in that expands to N single-ancestry runs, so every ADR-302 invariant holds per run. It does not inherit.
- **D5** — three detection layers; probing replays the story's own answer key rather than searching, so it is one walkthrough per probe. Unwinnable is reported by the coverage surface and stays out of the point-and-class catalog.
- **D6** — ADR-131's explorer is widened rather than replaced, and the static dead-end analysis moves out of the VS Code extension into the IDE.

`adr-review` scored it **7/17, NEEDS WORK**, and caught two citation failures that are corrected in place with dated notes: ADR-293 D15 is the coverage *report*, not a registry (which had made D5's central sentence self-contradictory), and Miller columns were attributed to ADR-301, which is TBD and specifies no surface.

**ADR-303 stays DRAFT** — no acceptance criteria, no test requirements, no implementation section, three interfaces undefined. It records decisions for work nobody has scheduled.

## Verification (2026-08-05)

| check | result |
|---|---|
| `./repokit verify` | 33 packages, publish dry-run **OK** |
| engine | **627 passed**, 7 skipped — +8 new |
| bootstrap | 40 passed — incl. a real-path #227 case |
| branch-tester | 352 passed |
| transcript-tester | 253 passed |
| stdlib | 1604 passed, 27 skipped |
| Fernhill tree | 22 passed — 552 commands |
| Dungeo v1 chain | 952 passed |

Closes #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
