### PR TITLE
Retire the transcript-test/branch-test bins; sharpee test --tree; ADR-131 widening

### DIFF
--- a/branch-stories/tree-npm-fixture/package.json
+++ b/branch-stories/tree-npm-fixture/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@sharpee/story-tree-npm-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Minimal tree-shaped story proving sharpee test --tree survives an npm install (ADR-302)",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@sharpee/core": "workspace:*",
+    "@sharpee/engine": "workspace:*",
+    "@sharpee/lang-en-us": "workspace:*",
+    "@sharpee/parser-en-us": "workspace:*",
+    "@sharpee/stdlib": "workspace:*",
+    "@sharpee/world-model": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  },
+  "license": "MIT"
+}

--- a/branch-stories/tree-npm-fixture/src/index.ts
+++ b/branch-stories/tree-npm-fixture/src/index.ts
@@ -1,0 +1,101 @@
+/**
+ * Tree npm fixture — the smallest module story that forms a transcript TREE.
+ *
+ * Purpose: `./repokit test:npm --tree` needs a story it can install from npm
+ * tarballs and run as an ADR-302 tree. Fernhill cannot serve — it is a bare
+ * Chord `.story` with no `package.json` and no `src/`, and `test:npm` requires
+ * both. This fixture exists solely to prove the tree path survives a real npm
+ * install; it is not a game and has no content beyond what its three
+ * transcripts assert.
+ *
+ * Shape (one root, two children — so a prefix is REPLAYED, not merely run):
+ *   spine ──┬── lamp      examines the lamp from the Vestibule
+ *           └── gallery   walks north
+ *
+ * That is 3 authored commands and 1 replayed, which is the D17 arithmetic the
+ * consumer run asserts. A single-child tree would not exercise replay at all.
+ *
+ * Public interface: TreeNpmFixtureStory (default story export).
+ * Owner context: platform test infrastructure (branch-stories/, ADR-302 D16).
+ */
+import type { Story, StoryConfig } from '@sharpee/engine';
+import {
+  WorldModel,
+  IdentityTrait,
+  ActorTrait,
+  RoomTrait,
+  ContainerTrait,
+  SceneryTrait,
+  EntityType,
+  Direction,
+} from '@sharpee/world-model';
+
+export class TreeNpmFixtureStory implements Story {
+  config: StoryConfig = {
+    id: 'tree-npm-fixture',
+    title: 'Tree npm Fixture',
+    authors: ['Sharpee platform tests'],
+    version: '1.0.0',
+    description: 'Minimal tree-shaped story for the npm consumer proof (ADR-302)',
+  };
+
+  createPlayer(world: WorldModel) {
+    const player = world.createEntity('yourself', EntityType.ACTOR);
+    player.add(new ActorTrait({ isPlayer: true }));
+    player.add(new ContainerTrait());
+    player.add(
+      new IdentityTrait({
+        name: 'yourself',
+        description: 'As good-looking as ever.',
+      }),
+    );
+    return player;
+  }
+
+  initializeWorld(world: WorldModel): void {
+    const vestibule = world.createEntity('vestibule', EntityType.ROOM);
+    vestibule.add(new RoomTrait());
+    vestibule.add(
+      new IdentityTrait({
+        name: 'Vestibule',
+        description: 'A narrow vestibule with a brass lamp on a bracket.',
+      }),
+    );
+
+    const gallery = world.createEntity('gallery', EntityType.ROOM);
+    gallery.add(new RoomTrait());
+    gallery.add(
+      new IdentityTrait({
+        name: 'Gallery',
+        description: 'A long gallery, entirely empty.',
+      }),
+    );
+
+    const vestibuleRoom = vestibule.get(RoomTrait) as RoomTrait;
+    const galleryRoom = gallery.get(RoomTrait) as RoomTrait;
+    vestibuleRoom.exits = { [Direction.NORTH]: { destination: gallery.id } };
+    galleryRoom.exits = { [Direction.SOUTH]: { destination: vestibule.id } };
+
+    const lamp = world.createEntity('lamp', EntityType.SCENERY);
+    lamp.add(new SceneryTrait());
+    lamp.add(
+      new IdentityTrait({
+        name: 'brass lamp',
+        aliases: ['lamp', 'brass'],
+        description: 'A brass lamp, unlit and slightly tarnished.',
+      }),
+    );
+    world.moveEntity(lamp.id, vestibule.id);
+
+    world.moveEntity(world.getPlayer()!.id, vestibule.id);
+  }
+}
+
+/**
+ * Story factory (ADR-248): the module's sole story export. Each call returns a
+ * fully fresh instance — which is exactly what a tree run needs, since D17
+ * boots a new game per root and per fork rather than restoring one.
+ */
+export function createStory(): TreeNpmFixtureStory {
+  return new TreeNpmFixtureStory();
+}

--- a/branch-stories/tree-npm-fixture/tests/transcripts/gallery.transcript
+++ b/branch-stories/tree-npm-fixture/tests/transcripts/gallery.transcript
@@ -1,0 +1,12 @@
+title: Tree fixture — the gallery
+story: tree-npm-fixture
+continues: spine
+description: Second child, and the reason this fixture has two. A sibling after
+  the first cannot continue the live engine, so it boots a fresh game and
+  replays the spine — which is the one replayed command the consumer run
+  asserts.
+
+---
+
+> north
+[OK: contains "Gallery"]

--- a/branch-stories/tree-npm-fixture/tests/transcripts/lamp.transcript
+++ b/branch-stories/tree-npm-fixture/tests/transcripts/lamp.transcript
@@ -1,0 +1,10 @@
+title: Tree fixture — the lamp
+story: tree-npm-fixture
+continues: spine
+description: First child. It continues the LIVE engine the spine left running,
+  so nothing is replayed for it.
+
+---
+
+> examine the brass lamp
+[OK: contains "tarnished"]

--- a/branch-stories/tree-npm-fixture/tests/transcripts/spine.transcript
+++ b/branch-stories/tree-npm-fixture/tests/transcripts/spine.transcript
@@ -1,0 +1,12 @@
+title: Tree fixture — the spine
+story: tree-npm-fixture
+description: The one root. Both children continue from the state this leaves,
+  so its single command is the prefix that gets replayed exactly once (ADR-302
+  D17 — the first child continues the live engine, the second reboots and
+  replays).
+seed: 42
+
+---
+
+> look
+[OK: contains "Vestibule"]

--- a/branch-stories/tree-npm-fixture/tsconfig.json
+++ b/branch-stories/tree-npm-fixture/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/architecture/adrs/adr-131-automated-world-explorer.md
+++ b/docs/architecture/adrs/adr-131-automated-world-explorer.md
@@ -4,22 +4,32 @@
 or `repokit` implements it.
 **Date:** 2026-02-18
 
-> **SCOPE QUESTION OPENED 2026-08-05 (session f2a7e6)** — see
-> [ADR-303 Q-3](adr-303-convergent-paths-and-unwinnable-states.md). This ADR is
-> a *regression-baseline generator*, and says so: BFS the rooms, probe entities
-> and description nouns, record outputs, diff later. It excludes reachability by
-> design — "This avoids the hard problem of puzzle-solving."
+> **SCOPE WIDENED 2026-08-05 (session 51b5f4)**, replacing the scope question
+> opened earlier the same day (session f2a7e6). Resolved by
+> [ADR-303 D6](adr-303-convergent-paths-and-unwinnable-states.md): this ADR
+> **gains a second mode rather than being replaced**, and its *static* half
+> **moves out of the VS Code extension into the IDE**. Both are stated in the
+> Decision below.
 >
-> The open question is whether the same BFS bot should also probe whether the
-> **ending stays reachable** — an unwinnable state has no ending, no message and
-> no test, which is why it survives to ship (ADR-303 D1). That is the excluded
-> thing, so widening this ADR would replace its stated premise rather than
-> extend it, and the alternative is a separate tool.
+> The question was whether a BFS bot built as a *regression-baseline generator*
+> — BFS the rooms, probe entities and description nouns, record outputs, diff
+> later — should also probe whether the **ending stays reachable**. An
+> unwinnable state has no ending, no message and no test, which is why it
+> survives to ship (ADR-303 D1), and this ADR excludes reachability by design:
+> "This avoids the hard problem of puzzle-solving."
 >
-> Note also that the *static* half already ships elsewhere:
-> `tools/vscode-ext/src/world-explorer.ts` renders a World Index from
-> `--world-json` with dead-end and one-way-exit highlighting. Whether that moves
-> to the IDE is part of Q-3.
+> The earlier note argued from that exclusion that widening would *replace this
+> ADR's premise rather than extend it*. **That objection is retracted**, and the
+> reason is what ADR-303 D5's probe turned out to be: it replays the story's own
+> answer key from a state rather than searching for a win, so it solves no
+> puzzle. The excluded thing and the added thing are not the same thing, and the
+> exclusion under *Starting Point* survives the widening intact.
+>
+> **Amended ahead of its trigger.** ADR-303 D6 names *whoever accepts ADR-303*
+> as this amendment's owner, with acceptance as the trigger; ADR-303 is still
+> DRAFT. Landed early on David's instruction (session 51b5f4). The obligation D6
+> records is discharged here, and D6's own "ADR-131 stands unamended until that
+> lands" sentence is corrected in place to say so.
 
 ## Context
 
@@ -36,6 +46,37 @@ We need an automated system that methodically explores the entire game world, tr
 ## Decision
 
 Build an **Automated World Explorer** — a BFS-driven bot that systematically visits every room, interacts with every entity and description noun, and records all outputs. It runs against the existing game engine programmatically (same as the transcript runner) and produces a golden baseline that can be diffed on future runs.
+
+### Two modes over one walk (widened by ADR-303 D6, 2026-08-05)
+
+| Mode | Records | Cadence | Output |
+|------|---------|---------|--------|
+| **Baseline** | prose, events and flags per probe | often, diffed against a golden | regression findings |
+| **Reachability** | states from which the authored win may no longer be reachable | rarely, run deliberately | unwinnability *candidates*, never verdicts |
+
+They share the walk and differ in everything else, which is why a mode is the
+right seam and not a second tool. Phases 1–4 below specify the **baseline**
+mode. The **reachability** mode is specified by
+[ADR-303 D5](adr-303-convergent-paths-and-unwinnable-states.md) — three
+detection layers (declared invariants, irreversibility flags, probing) and a
+probe that replays the known winning suffix from a state rather than searching
+for a win — and is not restated here.
+
+> **Label collision, stated so it is not tripped over.** ADR-303 D5 divides its
+> *probing* layer into a **routine** mode (seeded from the states the suite
+> already reaches) and a **deep** mode (BFS the reachable space, dedupe by state
+> signature, probe the frontier). Those two sit *inside* the reachability mode
+> named above; they are not alternatives to the baseline mode.
+
+**The static half moves to the IDE — not into either mode above.**
+`tools/vscode-ext/src/world-explorer.ts` already computes the graph-computable
+portion of this idea — dead ends (rooms with one exit or fewer) and one-way
+exits, rendered as a World Index from `--world-json`. That is the cheap layer
+living in the wrong product. Its destination is the **IDE's** author surface,
+not this explorer's walk: it needs no engine run at all, only the world JSON.
+It **moves** rather than being mirrored — two copies of a reachability analysis
+will eventually disagree, and the disagreement would be discovered by an
+author.
 
 ## Design
 
@@ -155,6 +196,11 @@ On subsequent runs, diff output against baseline:
 
 `packages/transcript-tester/src/explorer.ts` — reuses the existing engine initialization and command execution from the transcript runner. New CLI flag: `--explore`.
 
+This is the home of **both modes** named in the Decision, since both are engine
+walks. The **static** dead-end/one-way analysis is not one of them and does not
+belong behind `--explore`: it reads `--world-json` without running the engine,
+and its destination is the IDE.
+
 ## Starting Point
 
 Start from a save state where:
@@ -164,6 +210,14 @@ Start from a save state where:
 - Minimal inventory (avoid carrying capacity issues)
 
 This avoids the hard problem of puzzle-solving and focuses on regression coverage.
+
+> **This exclusion survives the ADR-303 D6 widening, and is load-bearing in it.**
+> Reachability mode does not solve puzzles either: it replays a winning path the
+> finished story already ships. What changes is the *starting point* — baseline
+> mode starts from one all-puzzles-solved save, while reachability mode seeds
+> from many states (the suite's leaves in routine mode, a BFS frontier in deep
+> mode). The single privileged save above is a baseline-mode requirement, not an
+> explorer-wide one.
 
 ## Consequences
 
@@ -183,3 +237,19 @@ This avoids the hard problem of puzzle-solving and focuses on regression coverag
 **Neutral:**
 - Complements manual transcripts, doesn't replace them
 - Manual transcripts test sequences and puzzles; explorer tests breadth and error handling
+
+**Added by the ADR-303 D6 widening (2026-08-05):**
+- Reachability mode has a **prerequisite this ADR did not previously have**: the
+  story must ship a known winning path for the probe to replay. A story without
+  one gets baseline mode only.
+- Its findings are **candidates, not failures** — a failed suffix replay may
+  mean the route changed rather than the win being gone. Reporting them as
+  failures would train authors to ignore the surface.
+- Those findings do **not** enter ADR-293's point-and-class catalog; they are
+  reported by the coverage surface (ADR-293 D15) alongside ADR-302 D6's untaken
+  divergences, where the unit is already "a place the story can be in that
+  nothing tests" (ADR-303 D5).
+- Moving the static analysis out of `tools/vscode-ext` **removes a shipped VS
+  Code feature** from that extension. The move is not complete until the IDE
+  renders the World Index; until then, deleting the extension copy would leave
+  authors with neither.

--- a/docs/architecture/adrs/adr-185-ide-standalone-authoring-tool.md
+++ b/docs/architecture/adrs/adr-185-ide-standalone-authoring-tool.md
@@ -97,6 +97,13 @@ project — the same prerequisite `build` already has. Verification (2026-06-20)
   directly — devkit + typescript as devDeps resolve on the npm-script PATH — and the straggler `npx`
   calls in the standalone toolchain are removed.
 
+  > **AMENDED 2026-08-05 (session 51b5f4).** `npx transcript-test` is no longer a
+  > choice to make: the `transcript-test` and `branch-test` bins were **retired**,
+  > so no scaffold can call them. The transcript step is `sharpee test`
+  > (`sharpee test --tree` for an ADR-302 tree), which is what this bullet already
+  > wanted — devkit's own bin, invoked directly. `tools/repokit`'s `test:npm` was
+  > re-pointed the same session and is the worked example.
+
 **The IDE uses this same scaffold.** Creating a new story runs the installed `sharpee init`; the IDE
 builds/introspects by invoking the project's local `sharpee` bin (`node_modules/.bin`) — exactly what
 the template's scripts do. One scaffold definition, shipped in `@sharpee/devkit`, serves both CLI

--- a/docs/architecture/adrs/adr-303-convergent-paths-and-unwinnable-states.md
+++ b/docs/architecture/adrs/adr-303-convergent-paths-and-unwinnable-states.md
@@ -241,9 +241,18 @@ eventually disagree, and the disagreement would be discovered by an author.
 same commit as the acceptance — replacing its "SCOPE QUESTION OPENED" note with
 the widening recorded here, and stating the two modes in its Decision. The
 trigger is acceptance of this ADR; the owner is the accepter, not a later
-reader. ADR-131 stands unamended until that lands. This ADR does not edit
-ADR-131 itself: one writer per artifact, and an interview writes only the ADR
-under interview.
+reader. This ADR does not edit ADR-131 itself: one writer per artifact, and an
+interview writes only the ADR under interview.
+
+> **DISCHARGED EARLY 2026-08-05 (session 51b5f4).** ADR-131 no longer stands
+> unamended: it carries a **SCOPE WIDENED** note, the two modes in its Decision,
+> the static-half move, and four new Consequences. The amendment landed on
+> David's instruction *ahead of* the trigger above, with this ADR still DRAFT —
+> so the pairing the paragraph specifies (same commit as the acceptance) did not
+> happen, and an accepter should not look for it. What the acceptance still owes
+> ADR-131 is nothing; what it owes this ADR is the DRAFT → ACCEPTED flip on its
+> own merits (acceptance criteria, test requirements, implementation section,
+> and the three undefined interfaces).
 
 ---
 

--- a/docs/context/session-20260805-1707-feat-adr-300-302-channels-branch-tester.md
+++ b/docs/context/session-20260805-1707-feat-adr-300-302-channels-branch-tester.md
@@ -57,13 +57,19 @@ Claimed in conversation that D17 would remove it; that was wrong and is correcte
 
 ## Open Items
 
+### Resolved after this list was first written
+- The **latent hook collision** was filed as [#229](https://github.com/ChicagoDave/sharpee/issues/229), then fixed at the engine and **closed** — see §5. The survey that produced it found four callers, not the two first recorded here.
+
 ### Short Term
-- **Latent hook collision, same root cause as #227**, in two places D17 does not reach: `runner.ts`'s `captureEngineSave` (ADR-300 D18 divergence saves, fires before every command in golden *replay* mode) and `search.ts`'s per-candidate restore (ADR-293 D12). Probed the golden path — a child of `recorded` doing `restart` — and it **passed**, because `runGolden` only engages when a golden *file* exists and no v2 story has one. Reachable the first time a v2 story blesses a golden and that transcript or a descendant on its live engine uses `restart`. Unverified by execution; mechanism identical. David has not yet said whether to file it.
-- `key.transcript`'s description claims "Every test that needs to be inside starts here", which is false (`containers`, `npcs`, `tool-gates`, `fuse` all go inside from `arrival`). Predates this session; left alone.
+- **ADR-131's amendment is owed.** ADR-303 D6 names *whoever accepts ADR-303* as the flip owner, with acceptance as the trigger. ADR-303 did not flip, so ADR-131 correctly still carries its "SCOPE QUESTION OPENED" note rather than the widening. Unowned flips are how Status lines rot; this one has an owner and a trigger and is simply not yet due.
+- **ADR-303 is DRAFT and should stay there.** `adr-review` scored it 7/17: no acceptance criteria, no test requirements, no implementation section, and three undefined interfaces — the semantic state signature, the multi-parent syntax, and the `converges-with` grammar. It records decisions, not a buildable spec.
+- **The IDE Testing wire is unstarted.** The mocks and the code survey exist; the NDJSON stream still carries no parentage, no `unreached`, and no replay markers, so no view can render the tree. That was step one of the agreed plan and it remains step one.
+- `key.transcript`'s description claims "Every test that needs to be inside starts here", which is false (`containers`, `npcs`, `tool-gates`, `fuse` all reach the interior from `arrival`). Predates this session; left alone rather than churn a description.
 
 ### Long Term
-- ADR-302 **D6** (coverage of untaken divergences) still has no implementing phase; the tree reports `Coverage: 0 of 12 points fired, 12 never fired, 28 classes unobserved`. No AC covers it.
+- ADR-302 **D6** (coverage of untaken divergences) still has no implementing phase; the tree reports `Coverage: 0 of 12 points fired, 12 never fired, 28 classes unobserved`. No AC covers it — but ADR-303 D5 now gives it two concrete motivating cases, which it did not have before.
 - **AC-9**'s first clause stays blocked on pre-existing issue #224 (familyzoo tutorial type-check), outside this branch.
+- The two published mocks are **artifacts, not repository files**, per the standing rule that IDE work belongs to a parallel session. If the IDE session wants them as source, they need re-creating there rather than copying from the artifact URLs.
 
 ## Files Modified
 
@@ -174,7 +180,8 @@ parentage — plus `.unreached` on `Status`, and a wire that carries any of it.
 - **Blocker**: N/A
 - **Blocker Category**: N/A
 - **Estimated Remaining**: N/A
-- **Rollback Safety**: D17 is revertible as one commit (the deleted `captureSave`/`applySave` are recorded in a comment at their old site). The version bump is mechanical and independently revertible.
+- **Rollback Safety**: three independently revertible commits, all merged to `main` — `af78363c` (D17 + 4.4.0), `f878a80c` (engine hook merge), `4c767e69` (ADR-303, docs only). D17's deleted `captureSave`/`applySave` are recorded in a comment at their old site.
+- **Landed**: PR [#228](https://github.com/ChicagoDave/sharpee/pull/228) → `8f2f241e`, PR [#230](https://github.com/ChicagoDave/sharpee/pull/230) → `ea996c7d`. Branch level with `main`; working tree clean apart from the untracked `scripts/clodpod.sh`.
 
 ## Dependency/Prerequisite Check
 
@@ -202,4 +209,4 @@ parentage — plus `.unreached` on `Status`, and a wire that carries any of it.
 
 ---
 
-**Progressive update**: Session completed 2026-08-05, ~18:20 CDT
+**Progressive update**: Session completed 2026-08-05, ~19:05 CDT — finalized after both PRs merged.

--- a/docs/context/session-20260805-1946-feat-adr-300-302-channels-branch-tester.md
+++ b/docs/context/session-20260805-1946-feat-adr-300-302-channels-branch-tester.md
@@ -132,6 +132,45 @@ closed with the real cause. Two new issues filed:
 implementations) and [#232](https://github.com/ChicagoDave/sharpee/issues/232) (devkit's
 dead, drifted consumer-gen).
 
+### 7. #232 resolved by PROMOTION, and the filing was wrong
+Two of the issue's three claims did not survive checking. It is **not dead** —
+`commands/standalone-build.test.ts` uses `generateConsumer` to build the installed
+project for devkit's integration gate. And the suggested fix (delete, or re-export
+repokit's) is rejected by **ADR-187 R1** by name:
+
+> repokit is the in-repo **proving ground** … then **explicitly ported to devkit when
+> hardened**. The duplication is a deliberate staging gate … A shared module would
+> couple the shipped author tool to in-progress platform-dev work.
+
+The re-export was impossible regardless: `tools/repokit` is `"private": true` and
+absent from `ts-forge.config.json`, so a published devkit could never import it.
+
+The one true claim — four fixes behind — is, under ADR-187, an **overdue promotion**.
+repokit's hardened `consumer-gen.ts` and its tests were walked across by hand
+(`assertVendoredClosureComplete` / #201, npm-12 `npm pack --json` parsing, memoized
+packing, dev-closure vendoring), the harness constant became `@sharpee/devkit`, and
+the file header now carries the ADR-187 reasoning plus an explicit "do NOT collapse
+these" so the issue is not re-filed. devkit `consumer-gen.test.ts`: **17 passed**.
+
+### 8. The tree's npm-consumer gap, closed
+`test:npm` only ever ran the flat path, so `sharpee test --tree` was verified purely
+in-repo — on the side of the workspace-symlink line where #225's class of defect is
+invisible.
+
+**`branch-stories/tree-npm-fixture/`** is a new dedicated fixture: the smallest module
+story that forms a tree. Fernhill could not serve — it is a bare Chord `.story` with no
+`package.json` and no `src/`, both of which `test:npm` requires. The shape is one root
+with **two** children on purpose: a single child would continue the live engine and
+replay nothing, so it would not exercise D17 at all.
+
+`test:npm` gained `--tree`, mutually exclusive with `--chain` (D10), invoking the tree
+as ONE call because D11 assembles and validates before executing — a per-file tally
+would misreport a cascade as several failures (D13).
+
+**Caught a real defect on its first run**: the fixture had no `createStory()` export,
+and the tree run failed with the ADR-248 factory-contract error. Fixed; the gap-closing
+test earned its keep before it was even green.
+
 ## Key Decisions
 
 ### Extract rather than write a third copy
@@ -181,6 +220,19 @@ decide it by side effect.
 - Repo-wide grep for live `transcript-test`/`branch-test` invocations: only a stale
   `package-lock.json` entry under `tutorials/familyzoo/v2.0.0/`, which regenerates.
 
+### The tree's npm-consumer proof (§8) and the #232 promotion (§7)
+- `./repokit test:npm branch-stories/tree-npm-fixture --local --tree` → `added 75
+  packages`, `npx tsc` clean, tree run → **`3 passed`, `4 commands (3 authored + 1
+  replayed)`**, `RESULTS: 3 passing, 0 failures`. The replay count is the D17
+  arithmetic, now proven through a real install rather than only in-repo.
+- Same fixture through the bundle → identical: `3 passed`, `4 commands (3 authored +
+  1 replayed)`.
+- Guard: `./repokit test:npm … --tree --chain` → `--tree and --chain are mutually
+  exclusive`.
+- `repokit` **81 passed, 1 skipped**; `branch-tester` **360 passed**; `devkit`
+  **129 passed** (2 pre-existing `browser-core-build` failures on the moved Fernhill
+  path, untouched).
+
 ## Files Modified
 
 **Docs** (3): `adr-131-automated-world-explorer.md`,
@@ -207,11 +259,12 @@ decide it by side effect.
 - **The retirement is COMPLETE** — all four steps landed. What remains is downstream:
   [#231](https://github.com/ChicagoDave/sharpee/issues/231) and
   [#232](https://github.com/ChicagoDave/sharpee/issues/232), neither blocking.
-- **The tree path is not covered by `test:npm`.** Its glob is `tests/transcripts/*`
-  and it never runs a tree, so `sharpee test --tree` has no npm-consumer proof — only
-  the in-repo Fernhill run. A tree fixture in the consumer test would close it.
-- **`packages/devkit/src/consumer-gen.ts` is dead and drifted** — see §5. Deleting it
-  is a separate, explicit decision.
+- **Type-only symbols imported in value position are a repo-wide pattern, not a cloak
+  one-off.** `stories/concealment-test/src/index.ts:19` has the identical
+  `import { Story, StoryConfig } from '@sharpee/engine'`. Every module story is a
+  candidate; only cloak was fixed. A sweep is owed.
+- **`stories/concealment-test` still declares `@sharpee/text-service`** in its
+  dependencies, a package ADR-174 removed.
 - **`test:npm` is red for two stories on pre-existing stale source** — familyzoo
   (#224) and cloak-of-darkness (`@sharpee/text-service`, removed by ADR-174). Neither
   is caused by this branch, and both make the gate unusable as written.

--- a/docs/context/session-20260805-1946-feat-adr-300-302-channels-branch-tester.md
+++ b/docs/context/session-20260805-1946-feat-adr-300-302-channels-branch-tester.md
@@ -1,0 +1,263 @@
+# Session Summary: 2026-08-05 19:46 CDT - feat/adr-300-302-channels-branch-tester
+
+## Goals
+- Amend ADR-131 with the ADR-303 D6 widening (a short-term open item from session f2a7e6).
+- Then: decide the fate of the package CLIs, and build what their retirement requires.
+
+## Phase Context
+- **Plan**: `docs/work/branch-tester/plan-20260805-branch-tester.md` — 11 phases, all COMPLETE. No phase advanced; this session paid a documentation debt and then started the CLI retirement, which the plan does not cover.
+
+## Completed
+
+### 1. ADR-131 amended — scope question closed, widening recorded
+The "SCOPE QUESTION OPENED" header note is replaced by **SCOPE WIDENED**, with four
+changes underneath it: the **two modes** stated in the Decision as a table (baseline
+vs reachability, with Phases 1–4 marked as the baseline mode and reachability cited to
+ADR-303 D5); a **label collision** called out (ADR-303 D5's *routine*/*deep* modes sit
+**inside** reachability, they are not alternatives to baseline); the **static half's
+destination named as the IDE**, with *Implementation Location* adding that it must not
+sit behind `--explore` because it reads `--world-json` without running the engine; and
+the **retraction recorded rather than deleted** — the old "widening would replace its
+premise" objection, with D5's answer-key replay as the reason it fails.
+
+Four consequences added (a winning path is now a prerequisite; findings are candidates
+not failures; they report via ADR-293 D15 and not the point catalog; the move removes a
+shipped VS Code feature, so it is incomplete until the IDE renders the World Index).
+*Starting Point* annotated: its single all-puzzles-solved save is a baseline-mode
+requirement, not an explorer-wide one.
+
+**Amended ahead of its trigger, and said so in both files.** ADR-303 D6 names whoever
+accepts ADR-303 as the owner, with acceptance as the trigger; ADR-303 is still DRAFT.
+ADR-131 carries an "Amended ahead of its trigger" paragraph, and ADR-303 D6 gains a
+dated **DISCHARGED EARLY** note correcting its now-false "ADR-131 stands unamended"
+sentence. Accepting ADR-303 to satisfy the trigger was rejected: it scored 7/17, and
+flipping a Status line to unlock a doc edit is the rot pattern, not a fix for it.
+
+### 2. Issue #225 disproved, and a real story defect found underneath it
+#225 claims the package CLIs "cannot load any story." **False** — `stories/dungeo` runs
+through `packages/transcript-tester/dist/cli.js` (2 passed). The failure was confined to
+`cloak-of-darkness`, which imported **two** type-only symbols in value position:
+`IScopeRule` (`@sharpee/world-model`) and `Story`/`StoryConfig` (`@sharpee/engine`), all
+three confirmed TYPE ONLY by importing the built ESM barrels and checking membership.
+Both fixed with `import type`; the story now loads and runs 82 tests.
+
+**A separate finding, unfiled:** the two paths do not run the same artifact. Package CLI
+gives 63/82, the bundle gives 81/82 on identical transcripts — the bundle prefers the
+lone `cloak.story` (Chord) while the package CLI loads the TS module story at
+`src/index.ts`. Cloak-of-darkness has two divergent implementations.
+
+**Not established:** how `src/index.ts` is loaded at all. There is no `dist/`, and the
+CLI registers no TS loader hook. An earlier claim in-session that "the bundle hides this
+because esbuild strips types" was inference and is withdrawn. What is verified is the
+causal chain: three runs, each changing one thing, error moved `IScopeRule` → `Story` →
+loads.
+
+### 3. `sharpee test --tree` — devkit gains the tree harness
+The retirement's blocking prerequisite: `branch-test` was the only author-facing entry
+to ADR-302's harness.
+
+- **`packages/branch-tester/src/game-factory.ts`** — `createRootGameFactory`, the one
+  implementation of D17's re-pin rule (a root booted at every fork below it must land on
+  the same master seed). Exported from the package index.
+- **`packages/branch-tester/src/cli.ts`** rewired to it — one hand-copied
+  `freshGameForRoot` gone.
+- **`packages/devkit/src/commands/test-tree.ts`** — the `--tree` run model over devkit's
+  own `loadAuthorGame`, so Chord `.story` projects work. The `branch-test` bin never
+  could: Chord compilation lives in the bundle.
+- Flag wiring in `test.ts`, usage text in `cli.ts`, `@sharpee/branch-tester` added to
+  devkit's dependencies.
+
+**Two guards made loud rather than silent.** `--tree --chain` exits 2 (ADR-302 D10
+retires `--chain`; honouring one silently would hide which model ran). `--tree --json`
+exits 2 because the ADR-277 record stream still carries no parentage, no `unreached` and
+no replay markers — a tree emitted through it would render as a flat run. **That guard
+should be removed the moment the IDE wire lands.**
+
+### 4. The bundle's copy retired too
+`scripts/bundle-entry.js` carried the third copy. It now calls
+`branchTester.createRootGameFactory`. What stays in the bundle is what is genuinely the
+CLI's: `resolveSeed`, carrying ADR-293 D1 precedence (`--seed` | `--vary` → `seed:` →
+clock). It runs *inside* `load`, so an override wins on the first boot and on every
+re-boot.
+
+### 5. Step 2 — `test:npm` re-pointed at `sharpee test`
+`tools/repokit/src/consumer-gen.ts`'s harness constant moved from
+`@sharpee/transcript-tester` to `@sharpee/devkit`, and `test-npm.ts` now spawns
+`npx sharpee test .` instead of `npx transcript-test .`. The result field
+`haveTranscriptTester` became `haveHarness`; the `#201` closure-vendoring logic is
+unchanged, it just walks devkit's closure instead.
+
+The proof is now **stronger than what it replaced**: an outside author runs
+`sharpee test`, never the package bin, so the consumer test exercises the command
+authors actually type.
+
+**Real-path verified (rule 13a), not stubbed**: `./repokit test:npm stories/dungeo
+--local --transcripts 'tests/transcripts/again-minimal.transcript'` → real `npm
+install` (79 packages), real `npx tsc`, real `npx sharpee test` → `2 passed`,
+`RESULTS: 1 passing, 0 failures`.
+
+**Three findings from running it for real:**
+- **`test:npm` is broadly red across the repo, for reasons that predate this work.**
+  The familyzoo tutorial dies at `npx tsc` (#224) before the harness is reached, so it
+  could not serve as the proof corpus. `cloak-of-darkness` dies differently — its
+  `src/test-runner.ts` still imports `@sharpee/text-service`, removed by ADR-174.
+  Two stories, two distinct stale-source failures. This is the concrete form of "a
+  gate that has been red and ignored."
+- **`stories/family-zoo-tutorial` has no transcripts at all** — the tutorial corpus
+  with tests is `tutorials/familyzoo/v2.0.0/`.
+- **`packages/devkit/src/consumer-gen.ts` is dead code.** It has no non-test caller;
+  only its own two test files import it. It is a stale copy of the function repokit
+  now owns (ADR-180/187 moved `test:npm` to repokit) and it has **drifted badly** — it
+  lacks `assertVendoredClosureComplete`, npm-12 pack parsing, memoized packing, and
+  the whole #201 dev-closure fix. Not deleted; flagged.
+
+### 6. Steps 3 and 4 — the bins are gone, the docs and issues follow
+**Step 3.** `bin` removed from `packages/transcript-tester/package.json`
+(`transcript-test`) and `packages/branch-tester/package.json` (`branch-test`).
+Neither `cli.ts` is deleted: both are relabelled **dev-only entry points** in their
+header docs, help text and index barrels, with the invocation spelled as
+`node packages/<pkg>/dist/cli.js`. transcript-tester's survival has a stated reason —
+it is the only surface that runs a story through Node's real ESM resolver, which is
+how #225's defect was found and what the bundle's esbuild path cannot do.
+
+Fixed in passing: branch-tester's help text advertised **`transcript-test`** and
+`stories/dungeo` throughout — a copy-paste artifact of ADR-302 D15's full-copy. It now
+names its own entry point and `branch-stories/fernhill`.
+
+**Step 4.** ADR-185's "No `npx`" bullet gained a dated amendment: `npx transcript-test`
+is no longer a choice, because the bin does not exist — the transcript step is
+`sharpee test`, which is what that bullet already wanted. [#225](https://github.com/ChicagoDave/sharpee/issues/225)
+closed with the real cause. Two new issues filed:
+[#231](https://github.com/ChicagoDave/sharpee/issues/231) (cloak's two divergent
+implementations) and [#232](https://github.com/ChicagoDave/sharpee/issues/232) (devkit's
+dead, drifted consumer-gen).
+
+## Key Decisions
+
+### Extract rather than write a third copy
+`freshGameForRoot` existed twice and the session-f2a7e6 notes record the second copy
+biting twice. A devkit copy would have been the third. Extraction was verified safe
+first: the two copies read the root's seed from **different fields**
+(`transcript.seed` vs `config.seeds[0]`), which looked like a live bug until
+`parseTranscriptFile` on a Fernhill root showed the parser mirrors `seed: 42` into both.
+The divergence is **latent** — only a `seeds:` matrix root would split them. The helper
+prefers the singular pin and falls back to the matrix, with a test pinning that.
+
+### Keep `test:npm`
+Asked whether the npm-consumer regression is still needed. It is: it is the only thing
+in the repo that reports #224 (the Family Zoo tutorial no longer type-checks against the
+platform). `./repokit verify` is `tsf build --npm` plus a publish **dry-run** — it proves
+the tarballs form, not that they work installed. Deleting it makes #224 unobservable, and
+the tutorial is what the book ships. The fair critique stands: it has been red and
+ignored, which launders confidence. Repair deliberately, do not let the bin question
+decide it by side effect.
+
+## Verification — all executed 2026-08-05 in-session
+
+- Fernhill tree via **devkit**: `22 passed`, `552 commands (518 authored + 34 replayed)`.
+- Fernhill tree via the **rebuilt bundle**: identical — `22 passed`, `552 commands (518
+  authored + 34 replayed)`. Seed announcements: 5 lines, `Seed: 42 (seed:)`, one per
+  root and not one per fork.
+- `--seed 99` override: `5 Seed: 99 (--seed)` — the CLI precedence survives extraction.
+- **Dungeo v1 chain**: `952 passed` in 17 transcripts — matches session f2a7e6 exactly.
+- `branch-tester`: **360 passed (28 files)**, up from 352 (+8 for `game-factory`).
+- `devkit` `test.test.ts`: **12 passed** (+4), including a real Chord compile and a real
+  tree run asserting D17 arithmetic exactly: `4 commands (3 authored + 1 replayed)`.
+- `tools/vscode-ext/src/world-explorer.ts` read before its behaviour was written into
+  ADR-131: one-way exits at 283–291, dead ends at 356.
+- `repokit`: **81 passed, 1 skipped (9 files)** after the harness swap.
+- **npm consumer real-path** (rule 13a): `./repokit test:npm stories/dungeo --local
+  --transcripts 'tests/transcripts/again-minimal.transcript'` → `added 79 packages`,
+  `npx tsc` clean, `npx sharpee test` → `2 passed`, `RESULTS: 1 passing, 0 failures`.
+
+### After the bins were removed (step 3), everything re-verified
+- `transcript-tester` **253 passed (21 files)**; `branch-tester` **360 passed (28 files)**.
+- Staged tarballs carry no bin: `grep -c bin` on both staged `package.json` files → `0`.
+- npm consumer proof re-run against the bin-less tarballs → `RESULTS: 1 passing, 0 failures`.
+- Dev-only entry point still runs: `node packages/transcript-tester/dist/cli.js
+  stories/dungeo …` → `2 passed`.
+- Fernhill, both paths, after a bundle rebuild → `22 passed`, `552 commands (518
+  authored + 34 replayed)`.
+- Repo-wide grep for live `transcript-test`/`branch-test` invocations: only a stale
+  `package-lock.json` entry under `tutorials/familyzoo/v2.0.0/`, which regenerates.
+
+## Files Modified
+
+**Docs** (3): `adr-131-automated-world-explorer.md`,
+`adr-303-convergent-paths-and-unwinnable-states.md`,
+`adr-185-ide-standalone-authoring-tool.md`.
+
+**Platform** (10): `packages/branch-tester/src/{game-factory.ts (new),index.ts,cli.ts}`,
+`packages/branch-tester/package.json` (bin removed),
+`packages/devkit/src/{commands/test-tree.ts (new),commands/test.ts,cli.ts}`,
+`packages/devkit/package.json`, `packages/transcript-tester/src/{index.ts,cli.ts}`,
+`packages/transcript-tester/package.json` (bin removed), `scripts/bundle-entry.js`.
+
+**Build tooling** (2): `tools/repokit/src/consumer-gen.ts`,
+`tools/repokit/src/commands/test-npm.ts`.
+
+**Tests** (3): `packages/branch-tester/tests/game-factory.test.ts` (new),
+`packages/devkit/src/commands/test.test.ts`, `tools/repokit/src/consumer-gen.test.ts`.
+
+**Story** (1): `stories/cloak-of-darkness/src/index.ts` — two type-only import fixes.
+
+## Open Items
+
+### Short Term
+- **The retirement is COMPLETE** — all four steps landed. What remains is downstream:
+  [#231](https://github.com/ChicagoDave/sharpee/issues/231) and
+  [#232](https://github.com/ChicagoDave/sharpee/issues/232), neither blocking.
+- **The tree path is not covered by `test:npm`.** Its glob is `tests/transcripts/*`
+  and it never runs a tree, so `sharpee test --tree` has no npm-consumer proof — only
+  the in-repo Fernhill run. A tree fixture in the consumer test would close it.
+- **`packages/devkit/src/consumer-gen.ts` is dead and drifted** — see §5. Deleting it
+  is a separate, explicit decision.
+- **`test:npm` is red for two stories on pre-existing stale source** — familyzoo
+  (#224) and cloak-of-darkness (`@sharpee/text-service`, removed by ADR-174). Neither
+  is caused by this branch, and both make the gate unusable as written.
+- **Neither `cli.ts` is deleted** — removing a `bin` entry unpublishes the command
+  without destroying the code. Deletion is a separate, explicit decision.
+- **Pre-existing devkit failure, untouched**: `src/standalone/browser-core-build.test.ts`
+  (2 cases) hardcodes `stories/fernhill/fernhill.story`; ADR-302 D16 moved Fernhill to
+  `branch-stories/`. Nothing this session goes near `src/standalone/`.
+- **The IDE Testing wire is still unstarted** — and now has a second dependant: the
+  `--tree --json` guard exists only because the stream carries no tree records.
+- **ADR-303 is DRAFT and should stay there** — no ACs, no test requirements, no
+  implementation section, three undefined interfaces.
+
+### Long Term
+- ADR-302 **D6** (coverage of untaken divergences) still has no implementing phase.
+- ADR-131 remains **unbuilt**; the widening enlarges a design that does not exist yet.
+- The static-half move is recorded but not performed, and per the new consequence
+  `world-explorer.ts` must not be deleted until the IDE renders the World Index.
+
+---
+
+## Session Metadata
+
+- **Status**: COMPLETE
+- **Blocker**: N/A
+- **Rollback Safety**: docs, platform and story changes are separable. The bundle change
+  is one hunk in `runBranchTree`; the extracted helper is additive (the old closures were
+  replaced, not deleted from history).
+
+## Architectural Decisions
+- No new ADR. Discharges the ADR-303 D6 amendment obligation. **Possibly ADR-worthy and
+  not yet raised**: retiring a published bin and relocating the npm-consumer proof to
+  devkit is a dependency-direction change a future session would otherwise re-litigate.
+
+## Mutation Audit
+Behavior Statement produced before tests (rule 12) for `createRootGameFactory`: DOES —
+invokes the caller's `load` with the root's entry/channels/stem and a seed; on a root's
+first boot records `masterSeedOf(game) ?? declaredSeed(root)` and calls `onFirstBoot`
+once; on every later boot of that stem passes the recorded seed instead of re-reading the
+header. REJECTS WHEN — nothing; a throwing `load` propagates unchanged and remembers
+nothing, and `masterSeedOf` returning undefined falls back to the declared pin. Each line
+has a test (8 cases). The `mutation-verification` agent was not run — subagents are
+disabled in this session's configuration.
+
+## Test Coverage Delta
+- **+12 tests**: 8 in `branch-tester/tests/game-factory.test.ts`, 4 in devkit's
+  `test.test.ts`.
+- Known untested: `test-tree.ts`'s exit-3 path (a boot failure mid-tree) has no unit
+  test; it is covered only by inspection. ADR-302 D6 remains unimplemented.

--- a/packages/branch-tester/package.json
+++ b/packages/branch-tester/package.json
@@ -4,9 +4,6 @@
   "description": "Tree-native transcript testing for Sharpee: a transcript names its parent, every test is a branch, and a run covers every root-to-leaf path (ADR-302)",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "branch-test": "./dist/cli.js"
-  },
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
     "dev": "tsc --watch",

--- a/packages/branch-tester/src/cli.ts
+++ b/packages/branch-tester/src/cli.ts
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 
 /**
- * Branch Tester CLI (ADR-302).
+ * Branch Tester CLI (ADR-302) — dev-only entry point, NO LONGER A PUBLISHED BIN.
  *
- * Usage:
- *   branch-test <story-path> [transcript-files...]
- *   branch-test <story-path> --all
- *   branch-test <story-path> --verbose
+ * The `branch-test` bin was retired in favour of `sharpee test --tree` (devkit),
+ * which drives this package as a LIBRARY and can load a Chord `.story` — which
+ * this file never could, since Chord compilation lives in the bundle.
+ *
+ * Usage (run the file directly; there is no installed command):
+ *   node packages/branch-tester/dist/cli.js <story-path> [transcript-files...]
+ *   node packages/branch-tester/dist/cli.js <story-path> --all
  */
 
 import * as path from 'path';
@@ -14,8 +17,9 @@ import * as fs from 'fs';
 import * as readline from 'readline';
 import { parseTranscriptFile, validateTranscript } from './parser.js';
 import { runTranscript } from './runner.js';
-import { assembleTree, type TreeNode } from './tree.js';
+import { assembleTree } from './tree.js';
 import { runTree } from './tree-runner.js';
+import { createRootGameFactory } from './game-factory.js';
 import { formatTreeRun } from './tree-report.js';
 import {
   reportTranscript,
@@ -118,12 +122,17 @@ function printHelp(): void {
   console.log(`
 Branch Tester - Test Sharpee stories as a tree of transcripts
 
+This is a dev-only entry point. There is no installed \`branch-test\` command:
+authors run \`sharpee test --tree\`, and the in-repo path is
+\`dist/cli/sharpee.js --test\` over transcripts under branch-stories/.
+This entry point cannot load a Chord \`.story\` — that lives in the bundle.
+
 Usage:
-  transcript-test <story-path> [transcript-files...] [options]
-  transcript-test <story-path> --play
+  node packages/branch-tester/dist/cli.js <story-path> [transcript-files...] [options]
+  node packages/branch-tester/dist/cli.js <story-path> --play
 
 Arguments:
-  story-path         Path to the story directory (e.g., stories/dungeo)
+  story-path         Path to the story directory (e.g., branch-stories/fernhill)
   transcript-files   One or more .transcript files to run
 
 Options:
@@ -139,12 +148,11 @@ Options:
   -o, --output-dir <dir> Write timestamped results to directory (JSON + text report)
   -h, --help             Show this help message
 
-Examples:
-  transcript-test stories/dungeo --play
-  transcript-test stories/dungeo tests/navigation.transcript
-  transcript-test stories/dungeo --all
-  transcript-test stories/dungeo tests/*.transcript --verbose
-  transcript-test stories/dungeo --all -o test-results
+Examples (CLI="node packages/branch-tester/dist/cli.js"):
+  $CLI branch-stories/fernhill --all
+  $CLI branch-stories/fernhill tests/transcripts/arrival.transcript
+  $CLI branch-stories/fernhill --all --verbose
+  $CLI branch-stories/fernhill --all -o test-results
 `);
 }
 
@@ -422,21 +430,11 @@ async function main(): Promise<void> {
   // fresh clock seed per boot, and its replayed prefix would then diverge from
   // the one its first child saw. Whatever the first boot resolved is remembered
   // and re-pinned.
-  const bootedSeeds = new Map<string, number>();
-  const freshGameForRoot = async (root: TreeNode): Promise<TestableGame> => {
-    const header = root.transcript;
-    const game = await loadStory(
-      options.storyPath,
-      header.header.entry,
-      bootedSeeds.get(root.stem) ?? header.config?.seeds?.[0],
-      header.config?.channels ?? []
-    );
-    if (!bootedSeeds.has(root.stem)) {
-      const seed = (game as { engine?: { getMasterSeed?(): number } }).engine?.getMasterSeed?.();
-      if (seed !== undefined) bootedSeeds.set(root.stem, seed);
-    }
-    return game;
-  };
+  const freshGameForRoot = createRootGameFactory<TestableGame>({
+    load: (spec) => loadStory(options.storyPath, spec.entry, spec.seed, spec.channels),
+    masterSeedOf: (game) =>
+      (game as { engine?: { getMasterSeed?(): number } }).engine?.getMasterSeed?.(),
+  });
 
   let run;
   try {

--- a/packages/branch-tester/src/game-factory.ts
+++ b/packages/branch-tester/src/game-factory.ts
@@ -1,0 +1,102 @@
+/**
+ * game-factory.ts — build the `GameFactory` a tree walk needs, once.
+ *
+ * ADR-302 D1 makes a root a fresh game; D17 makes every divergent sibling one
+ * too. So the same root is booted several times in one run, and all of those
+ * boots must land on the SAME master seed — a root that declared no `seed:`
+ * would otherwise draw a fresh clock seed per boot, and the prefix replayed for
+ * a later sibling would diverge from the one the first child actually saw. The
+ * seed the first boot resolved is therefore remembered per root stem and
+ * re-pinned on every subsequent boot.
+ *
+ * This lived as a hand-copied closure in each caller (`cli.ts` and the bundle's
+ * `scripts/bundle-entry.js`). The copies drifted — one read the root's seed from
+ * `transcript.seed`, the other from `config.seeds[0]` — and the re-pin rule had
+ * to be rediscovered when the bundle copy was missed. One implementation, three
+ * callers.
+ *
+ * Public interface: createRootGameFactory(options) → GameFactory.
+ * Owner context: @sharpee/branch-tester (test infrastructure).
+ */
+import type { TreeNode } from './tree.js';
+
+/** What a caller's loader needs in order to boot a root. */
+export interface RootBootSpec {
+  /** The root's `entry:` header field — a module story's sub-entry, if any. */
+  entry?: string;
+  /**
+   * The seed to boot at: the root's own pin on the first boot, and thereafter
+   * whatever that first boot actually resolved. `undefined` only when the root
+   * pinned nothing AND the first boot reported no master seed.
+   */
+  seed?: number;
+  /** The root's declared `channels:`, empty when it declared none. */
+  channels: string[];
+  /** The root's stem (filename identity, ADR-302 D14) — for diagnostics. */
+  stem: string;
+}
+
+export interface RootGameFactoryOptions<G> {
+  /** Boot one fresh game. Called once per root, then once per fork below it. */
+  load: (spec: RootBootSpec) => Promise<G>;
+  /**
+   * Read the master seed a booted game actually resolved. Returning `undefined`
+   * disables re-pinning for that root, which is correct only when the caller's
+   * engine cannot report one.
+   */
+  masterSeedOf: (game: G) => number | undefined;
+  /**
+   * Called once per root, on its FIRST boot only, with the seed that boot
+   * resolved. Callers that announce the seed do it here so the announcement is
+   * not repeated at every fork.
+   */
+  onFirstBoot?: (stem: string, seed: number | undefined) => void;
+}
+
+/**
+ * The root's declared pin, preferring the singular `seed:` and falling back to
+ * the first entry of a `seeds:` matrix.
+ *
+ * The parser mirrors `seed: N` into `config.seeds` as a single entry, so for the
+ * singular form the two agree. They part only on a `seeds: A, B` matrix root,
+ * where `transcript.seed` is unset — the matrix's first entry is the boot seed,
+ * matching how the runner threads a matrix per recording.
+ */
+function declaredSeed(root: TreeNode): number | undefined {
+  const transcript = root.transcript as { seed?: number; config?: { seeds?: number[] } };
+  return transcript.seed ?? transcript.config?.seeds?.[0];
+}
+
+/**
+ * Build the `GameFactory` passed to `runTree`.
+ *
+ * @param options the caller's loader, its master-seed reader, and an optional
+ *   first-boot hook.
+ * @returns a factory that boots a fresh game per root, re-pinning each root's
+ *   resolved seed on every boot after the first.
+ */
+export function createRootGameFactory<G>(options: RootGameFactoryOptions<G>): (root: TreeNode) => Promise<G> {
+  const { load, masterSeedOf, onFirstBoot } = options;
+  /** stem → the master seed that root's first boot resolved. */
+  const bootedSeeds = new Map<string, number | undefined>();
+
+  return async (root: TreeNode): Promise<G> => {
+    const stem = root.stem;
+    const booted = bootedSeeds.has(stem);
+    const header = root.transcript as { header?: { entry?: string }; config?: { channels?: string[] } };
+
+    const game = await load({
+      entry: header.header?.entry,
+      seed: booted ? bootedSeeds.get(stem) : declaredSeed(root),
+      channels: header.config?.channels ?? [],
+      stem,
+    });
+
+    if (!booted) {
+      const resolved = masterSeedOf(game) ?? declaredSeed(root);
+      bootedSeeds.set(stem, resolved);
+      onFirstBoot?.(stem, resolved);
+    }
+    return game;
+  };
+}

--- a/packages/branch-tester/src/index.ts
+++ b/packages/branch-tester/src/index.ts
@@ -14,8 +14,9 @@
  * a fiction — every change here would be a change there. The split is
  * permanent and by story, not a migration with an end date.
  *
- * Usage:
- *   npx branch-test <story-path> [transcripts...]
+ * Usage: as a LIBRARY. The `branch-test` bin is retired — an author runs
+ * `sharpee test --tree` (devkit), and the in-repo path is the bundle's `--test`
+ * over transcripts under branch-stories/.
  */
 
 // Types
@@ -43,6 +44,14 @@ export {
   type TreeRunResult,
   type NodeRunOutcome,
 } from './tree-runner.js';
+
+// The one `GameFactory` builder — a root's resolved seed is re-pinned at every
+// fork below it (ADR-302 D17). One implementation for cli.ts, devkit, the bundle.
+export {
+  createRootGameFactory,
+  type RootBootSpec,
+  type RootGameFactoryOptions,
+} from './game-factory.js';
 
 // Tree reporting — unreached is not failed (ADR-302 D13)
 export {

--- a/packages/branch-tester/tests/game-factory.test.ts
+++ b/packages/branch-tester/tests/game-factory.test.ts
@@ -1,0 +1,149 @@
+/**
+ * game-factory.test.ts — the one `GameFactory` builder (ADR-302 D1 + D17).
+ *
+ * Each case traces to a line of `createRootGameFactory`'s Behavior Statement.
+ * The assertions are on the seeds the factory PASSED to `load` across a run —
+ * that sequence is the whole point of the unit, and a re-pin that fails shows
+ * up here as a differing seed rather than as a content failure downstream.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRootGameFactory, type RootBootSpec } from '../src/game-factory.js';
+import type { TreeNode } from '../src/tree.js';
+
+/** A TreeNode stub carrying only what the factory reads. */
+function node(stem: string, transcript: Record<string, unknown>): TreeNode {
+  return { stem, transcript } as unknown as TreeNode;
+}
+
+/** Records every spec `load` was called with, and reports a fixed master seed. */
+function recorder(masterSeed: number | undefined) {
+  const specs: RootBootSpec[] = [];
+  const factory = createRootGameFactory<{ id: number }>({
+    load: async (spec) => {
+      specs.push(spec);
+      return { id: specs.length };
+    },
+    masterSeedOf: () => masterSeed,
+  });
+  return { specs, factory };
+}
+
+describe('createRootGameFactory', () => {
+  it('passes the root\'s declared singular seed on the first boot', async () => {
+    const { specs, factory } = recorder(42);
+    await factory(node('arrival', { seed: 42, config: { seeds: [42] } }));
+
+    expect(specs).toHaveLength(1);
+    expect(specs[0].seed).toBe(42);
+    expect(specs[0].stem).toBe('arrival');
+  });
+
+  it('re-pins the resolved seed on every boot after the first', async () => {
+    // The root declared NOTHING, so each boot would otherwise draw a fresh
+    // clock seed — the exact D17 hazard. The engine resolved 987654.
+    const { specs, factory } = recorder(987654);
+    const root = node('unpinned', { config: {} });
+
+    await factory(root); // the root itself
+    await factory(root); // a fork below it
+    await factory(root); // another fork
+
+    expect(specs.map((s) => s.seed)).toEqual([undefined, 987654, 987654]);
+  });
+
+  it('keeps a separate remembered seed per root stem', async () => {
+    const seeds = new Map([
+      ['a', 111],
+      ['b', 222],
+    ]);
+    const specs: RootBootSpec[] = [];
+    const factory = createRootGameFactory<{ stem: string }>({
+      load: async (spec) => {
+        specs.push(spec);
+        return { stem: spec.stem };
+      },
+      masterSeedOf: (game) => seeds.get(game.stem),
+    });
+
+    const a = node('a', { config: {} });
+    const b = node('b', { config: {} });
+    await factory(a);
+    await factory(b);
+    await factory(a);
+    await factory(b);
+
+    expect(specs.map((s) => [s.stem, s.seed])).toEqual([
+      ['a', undefined],
+      ['b', undefined],
+      ['a', 111],
+      ['b', 222],
+    ]);
+  });
+
+  it('falls back to a `seeds:` matrix first entry when there is no singular pin', async () => {
+    // The latent divergence between the two hand-copied closures: one read
+    // `transcript.seed` (unset here), the other `config.seeds[0]`.
+    const { specs, factory } = recorder(7);
+    await factory(node('matrix', { config: { seeds: [7, 8, 9] } }));
+
+    expect(specs[0].seed).toBe(7);
+  });
+
+  it('forwards the root\'s entry and channels, defaulting channels to empty', async () => {
+    const { specs, factory } = recorder(1);
+    await factory(node('withEntry', { header: { entry: 'v16' }, config: { channels: ['banner'] } }));
+    await factory(node('bare', { config: {} }));
+
+    expect(specs[0].entry).toBe('v16');
+    expect(specs[0].channels).toEqual(['banner']);
+    expect(specs[1].entry).toBeUndefined();
+    expect(specs[1].channels).toEqual([]);
+  });
+
+  it('announces once per root, not once per boot', async () => {
+    const onFirstBoot = vi.fn();
+    const factory = createRootGameFactory<{ n: number }>({
+      load: async () => ({ n: 1 }),
+      masterSeedOf: () => 555,
+      onFirstBoot,
+    });
+    const root = node('once', { config: {} });
+
+    await factory(root);
+    await factory(root);
+    await factory(root);
+
+    expect(onFirstBoot).toHaveBeenCalledTimes(1);
+    expect(onFirstBoot).toHaveBeenCalledWith('once', 555);
+  });
+
+  it('remembers the declared pin when the engine reports no master seed', async () => {
+    const { specs, factory } = recorder(undefined);
+    const root = node('noReader', { seed: 313 });
+
+    await factory(root);
+    await factory(root);
+
+    expect(specs.map((s) => s.seed)).toEqual([313, 313]);
+  });
+
+  it('propagates a load failure unchanged and does not remember the stem', async () => {
+    let attempt = 0;
+    const specs: RootBootSpec[] = [];
+    const factory = createRootGameFactory<{ ok: true }>({
+      load: async (spec) => {
+        specs.push(spec);
+        attempt++;
+        if (attempt === 1) throw new Error('story is broken');
+        return { ok: true };
+      },
+      masterSeedOf: () => 99,
+    });
+    const root = node('fails', { config: {} });
+
+    await expect(factory(root)).rejects.toThrow('story is broken');
+    // The failed boot recorded nothing, so the retry still reads the header.
+    await factory(root);
+    expect(specs.map((s) => s.seed)).toEqual([undefined, undefined]);
+  });
+});

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@sharpee/bootstrap": "workspace:*",
+    "@sharpee/branch-tester": "workspace:*",
     "@sharpee/chord": "workspace:*",
     "@sharpee/core": "workspace:*",
     "@sharpee/engine": "workspace:*",

--- a/packages/devkit/src/cli.ts
+++ b/packages/devkit/src/cli.ts
@@ -44,8 +44,11 @@ Usage:
   sharpee register <location> [--name]   Register a name→path mapping in ~/.sharpee/devkit
   sharpee list                           List registered stories
   sharpee --version                      Print the platform + Chord language version
-  sharpee test [name|path] [transcripts…] [--chain] [--stop-on-failure] [--verbose]
+  sharpee test [name|path] [transcripts…] [--tree|--chain] [--stop-on-failure] [--verbose]
                                          Run the project's transcript tests
+                                         --tree: transcripts name parents with
+                                         continues:; runs every root-to-leaf
+                                         path (ADR-302)
   sharpee play [name|path]               Play the project interactively (REPL)
 
 build (Chord .story): compiles the story, derives all metadata from the Story IR

--- a/packages/devkit/src/commands/test-tree.ts
+++ b/packages/devkit/src/commands/test-tree.ts
@@ -1,0 +1,136 @@
+/**
+ * test-tree.ts — `sharpee test --tree`: run an author project's transcript TREE.
+ *
+ * Author-side entry point for @sharpee/branch-tester (ADR-302). A transcript
+ * names its parent with `continues:`, so the project's tests form a tree rather
+ * than a directory of independent files; running the harness runs every
+ * root-to-leaf path. There is deliberately no `--chain` here — ADR-302 D10
+ * retires it, because a tree run has no other meaning.
+ *
+ * This exists so retiring the `branch-test` bin costs an author nothing: the
+ * tree harness keeps an entry point, and it is the same command an author
+ * already types for flat transcripts.
+ *
+ * Public interface: runTreeTestCommand(options) → process exit code.
+ * Owner context: @sharpee/devkit (author tool).
+ */
+import { loadAuthorGame } from '../standalone/author-game.js';
+
+export interface TreeTestOptions {
+  /** Resolved project directory (the caller has already resolved name/dir/.story). */
+  dir: string;
+  /** Absolute `.transcript` paths forming the tree. */
+  transcripts: string[];
+  verbose: boolean;
+  stopOnFailure: boolean;
+}
+
+/**
+ * Run `sharpee test --tree`.
+ *
+ * @param options resolved project directory, the transcripts forming the tree,
+ *   and the run flags.
+ * @returns process exit code — 0 all passed, 1 failures, 2 a parse failure or a
+ *   tree defect (nothing ran), 3 the story failed to load. Never calls
+ *   `process.exit()`; the caller owns the process.
+ */
+export async function runTreeTestCommand(options: TreeTestOptions): Promise<number> {
+  // Lazy require (the test.ts pattern): pull the harness only when testing.
+  const {
+    aggregateTestRun,
+    assembleTree,
+    createRootGameFactory,
+    formatTreeRun,
+    getExitCode,
+    parseTranscriptFile,
+    reportTranscript,
+    runTree,
+    validateTranscript,
+  } = require('@sharpee/branch-tester') as typeof import('@sharpee/branch-tester');
+
+  const { dir, transcripts, verbose, stopOnFailure } = options;
+
+  console.log(`Loading story from: ${dir}`);
+
+  // ADR-302 D11: the tree is validated WHOLE before anything executes. A file
+  // that will not parse is not a failing test — it is a tree that cannot be
+  // assembled, so nothing runs and no partial result is offered.
+  const parsed = [];
+  const parseFailures: string[] = [];
+  for (const transcriptPath of transcripts) {
+    try {
+      const transcript = parseTranscriptFile(transcriptPath);
+      const errors = validateTranscript(transcript);
+      if (errors.length > 0) {
+        parseFailures.push(`${transcriptPath}: ${errors.join('; ')}`);
+        continue;
+      }
+      parsed.push(transcript);
+    } catch (error) {
+      parseFailures.push(`${transcriptPath}: ${error instanceof Error ? error.message : error}`);
+    }
+  }
+
+  if (parseFailures.length > 0) {
+    for (const failure of parseFailures) console.error(`  - ${failure}`);
+    console.error(`\n${parseFailures.length} transcript(s) failed to parse — nothing ran.`);
+    return 2;
+  }
+
+  const storyName = dir.split('/').filter(Boolean).pop() ?? dir;
+  const tree = assembleTree(parsed, storyName);
+  if (tree.defects.length > 0) {
+    // D11 again: every defect reported together. A tree with a cycle has no
+    // correct partial run to offer.
+    for (const line of formatTreeRun({
+      outcomes: [],
+      defects: tree.defects,
+      executedCommands: 0,
+      authoredCommands: 0,
+    })) {
+      console.error(line);
+    }
+    return 2;
+  }
+
+  // D1 + D17: one boot per root and one per divergent sibling, with the root's
+  // resolved seed re-pinned across all of them. The shared builder owns that
+  // rule — see game-factory.ts for why it is not inlined here.
+  let announcedLoadFailure = false;
+  const freshGameForRoot = createRootGameFactory({
+    load: (spec) => loadAuthorGame(dir, { entry: spec.entry, seed: spec.seed }),
+    masterSeedOf: (game) =>
+      (game as { engine?: { getMasterSeed?(): number } }).engine?.getMasterSeed?.(),
+    onFirstBoot: (stem, seed) => {
+      if (seed !== undefined) console.log(`Seed: ${seed} (${stem})`);
+    },
+  });
+
+  let run;
+  try {
+    run = await runTree(tree, freshGameForRoot as never, {
+      verbose,
+      stopOnFailure,
+      storyName,
+    });
+  } catch (error) {
+    // A boot failure and a non-deterministic replay both arrive here. Both mean
+    // the run produced no trustworthy result, so neither is reported as a test
+    // failure — exit 3 is "the story would not run", not "the story is wrong".
+    announcedLoadFailure = true;
+    console.error(`Error running the tree: ${error instanceof Error ? error.message : error}`);
+  }
+  if (announcedLoadFailure || !run) return 3;
+
+  for (const outcome of run.outcomes) {
+    if (outcome.result) reportTranscript(outcome.result, { verbose });
+  }
+
+  // D13: unreached is not failed. Printed after the runs, so the tally reads as
+  // blast radius rather than as more failures.
+  console.log();
+  for (const line of formatTreeRun(run)) console.log(line);
+
+  const results = run.outcomes.filter((o) => o.result !== undefined).map((o) => o.result!);
+  return getExitCode(aggregateTestRun(results));
+}

--- a/packages/devkit/src/commands/test.test.ts
+++ b/packages/devkit/src/commands/test.test.ts
@@ -128,6 +128,77 @@ describe('sharpee test (author project, Chord source)', () => {
   });
 });
 
+describe('sharpee test --tree (ADR-302 tree run)', () => {
+  let treeDir: string;
+
+  beforeAll(() => {
+    // A separate project: the flat suite above scans the same tests/ subtree,
+    // and a `continues:` file there would change what THAT suite runs.
+    treeDir = mkdtempSync(join(tmpdir(), 'devkit-test-tree-'));
+    writeFileSync(join(treeDir, 'mini.story'), STORY);
+    mkdirSync(join(treeDir, 'tests', 'transcripts'), { recursive: true });
+    writeFileSync(
+      join(treeDir, 'tests', 'transcripts', 'spine.transcript'),
+      `title: Spine\nseed: 42\n\n---\n\n> look\n[OK: contains "A small square den"]\n`,
+    );
+    // Two children off one parent: the prefix runs once for the first and is
+    // REPLAYED for the second (D17), which is what the tally must show.
+    writeFileSync(
+      join(treeDir, 'tests', 'transcripts', 'lamp.transcript'),
+      `title: Lamp\ncontinues: spine\n\n---\n\n> examine the brass lamp\n[OK: contains "gleams dully"]\n`,
+    );
+    writeFileSync(
+      join(treeDir, 'tests', 'transcripts', 'den.transcript'),
+      `title: Den again\ncontinues: spine\n\n---\n\n> look\n[OK: contains "A small square den"]\n`,
+    );
+  });
+
+  afterAll(() => rmSync(treeDir, { recursive: true, force: true }));
+
+  it('runs every root-to-leaf path against the REAL compiled story and passes (exit 0)', async () => {
+    const { code, out } = await muted(() => runTestCommand([treeDir, '--tree']));
+
+    expect(code).toBe(0);
+    // 3 nodes ran, and the second child replayed the parent's one command
+    // rather than the parent running twice — the D17 arithmetic, asserted.
+    expect(out).toContain('3 passed');
+    expect(out).toMatch(/4 commands \(3 authored \+ 1 replayed\)/);
+  });
+
+  it('reports a dangling parent as a tree defect and executes nothing (exit 2)', async () => {
+    const orphanDir = mkdtempSync(join(tmpdir(), 'devkit-test-orphan-'));
+    try {
+      writeFileSync(join(orphanDir, 'mini.story'), STORY);
+      mkdirSync(join(orphanDir, 'tests', 'transcripts'), { recursive: true });
+      writeFileSync(
+        join(orphanDir, 'tests', 'transcripts', 'orphan.transcript'),
+        `title: Orphan\ncontinues: nonexistent\n\n---\n\n> look\n[OK: contains "den"]\n`,
+      );
+
+      const { code, err } = await muted(() => runTestCommand([orphanDir, '--tree']));
+
+      expect(code).toBe(2);
+      expect(err).toContain('nonexistent');
+    } finally {
+      rmSync(orphanDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects --tree with --chain rather than silently picking one (exit 2)', async () => {
+    const { code, err } = await muted(() => runTestCommand([treeDir, '--tree', '--chain']));
+
+    expect(code).toBe(2);
+    expect(err).toContain('mutually exclusive');
+  });
+
+  it('refuses --tree with --json while the record stream carries no parentage (exit 2)', async () => {
+    const { code, err } = await muted(() => runTestCommand([treeDir, '--tree', '--json']));
+
+    expect(code).toBe(2);
+    expect(err).toContain('does not yet carry tree records');
+  });
+});
+
 describe('author-game story resolution', () => {
   it('finds the single root .story; two is a named error, never a guess', () => {
     expect(findStoryFile(projectDir)).toBe(join(projectDir, 'mini.story'));

--- a/packages/devkit/src/commands/test.ts
+++ b/packages/devkit/src/commands/test.ts
@@ -25,9 +25,12 @@ import type {
 } from '@sharpee/transcript-tester';
 import { loadAuthorGame } from '../standalone/author-game.js';
 import { lookupStory } from '../registry.js';
+// Cheap to import: test-tree.ts pulls @sharpee/branch-tester lazily, so the
+// harness still loads only when --tree is actually used.
+import { runTreeTestCommand } from './test-tree.js';
 
 const USAGE =
-  'usage: sharpee test [name|dir|file.story] [transcripts…] [--chain] [--stop-on-failure|-s] [--verbose|-v] [--json] [--coverage] [--capture-output]';
+  'usage: sharpee test [name|dir|file.story] [transcripts…] [--tree|--chain] [--stop-on-failure|-s] [--verbose|-v] [--json] [--coverage] [--capture-output]';
 
 /**
  * Run `sharpee test`.
@@ -67,6 +70,7 @@ export async function runTestCommand(rest: string[]): Promise<number> {
   } = require('@sharpee/transcript-tester') as typeof import('@sharpee/transcript-tester');
 
   let chain = false;
+  let tree = false;
   let stopOnFailure = false;
   let verbose = false;
   let json = false;
@@ -76,7 +80,8 @@ export async function runTestCommand(rest: string[]): Promise<number> {
   const transcriptPaths: string[] = [];
 
   for (const arg of rest) {
-    if (arg === '--chain' || arg === '-c') chain = true;
+    if (arg === '--tree') tree = true;
+    else if (arg === '--chain' || arg === '-c') chain = true;
     else if (arg === '--stop-on-failure' || arg === '-s') stopOnFailure = true;
     else if (arg === '--verbose' || arg === '-v') verbose = true;
     else if (arg === '--json') json = true;
@@ -117,6 +122,14 @@ export async function runTestCommand(rest: string[]): Promise<number> {
     }
   }
 
+  // ADR-302 D10 retires `--chain`: in a tree, a shared prefix already runs once
+  // and each tail resumes from it, so "chain" names nothing a tree run can mean.
+  // Silently ignoring one of the two would hide which model actually ran.
+  if (tree && chain) {
+    console.error(`test: --tree and --chain are mutually exclusive (ADR-302 D10 retires --chain for trees)\n${USAGE}`);
+    return 2;
+  }
+
   const dir = path.resolve(projectDir ?? process.cwd());
   let transcripts = transcriptPaths.map((p) => path.resolve(p));
   if (transcripts.length === 0) {
@@ -141,6 +154,20 @@ export async function runTestCommand(rest: string[]): Promise<number> {
     }
   }
   transcripts = [...new Set(transcripts)];
+
+  // A tree is a different run model, not a flag on this one: it assembles all
+  // transcripts before executing any, and its reporting distinguishes unreached
+  // from failed (D13). Hand off whole rather than branching through the loop.
+  if (tree) {
+    if (json) {
+      // The ADR-277 D1 record stream carries no parentage, no `unreached` and
+      // no replay markers yet, so a tree emitted through it would be reported
+      // as a flat run. Refusing beats emitting a shape that reads as truth.
+      console.error('test: --json does not yet carry tree records (parentage, unreached, replay) — run --tree without --json');
+      return 2;
+    }
+    return runTreeTestCommand({ dir, transcripts, verbose, stopOnFailure });
+  }
 
   // In --json mode, stdout is exclusively the NDJSON stream: informational
   // lines are dropped (diagnostics stay on stderr) and the chalk reporter

--- a/packages/devkit/src/consumer-gen.test.ts
+++ b/packages/devkit/src/consumer-gen.test.ts
@@ -3,10 +3,19 @@
  * Derived from the Behavior Statements for computeClosure and generateConsumer.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { computeClosure, scanStaging, readSharpeeSeed, generateConsumer } from './consumer-gen.js';
+import {
+  computeClosure,
+  scanStaging,
+  readSharpeeSeed,
+  declaredSharpeeDeps,
+  stagingDepsOf,
+  assertVendoredClosureComplete,
+  generateConsumer,
+  packFilenameFrom,
+} from './consumer-gen.js';
 
 describe('computeClosure', () => {
   it('returns the full transitive set including the seed', () => {
@@ -29,6 +38,73 @@ describe('computeClosure', () => {
   });
 });
 
+describe('assertVendoredClosureComplete', () => {
+  it('accepts a set whose declared @sharpee deps are all vendored', () => {
+    const declared: Record<string, string[]> = {
+      '@sharpee/engine': ['@sharpee/core'],
+      '@sharpee/core': [],
+    };
+    expect(() =>
+      assertVendoredClosureComplete(['@sharpee/engine', '@sharpee/core'], (n) => declared[n] ?? []),
+    ).not.toThrow();
+  });
+
+  it('throws naming the unvendored dep and the package that requires it', () => {
+    // The #201 shape: devkit is vendored, its bootstrap dep is not, so npm
+    // would resolve bootstrap from the registry and fail install with ETARGET.
+    const declared: Record<string, string[]> = {
+      '@sharpee/devkit': ['@sharpee/core', '@sharpee/bootstrap'],
+      '@sharpee/core': [],
+    };
+    expect(() =>
+      assertVendoredClosureComplete(
+        ['@sharpee/devkit', '@sharpee/core'],
+        (n) => declared[n] ?? [],
+      ),
+    ).toThrow(/@sharpee\/bootstrap \(required by @sharpee\/devkit\)/);
+  });
+});
+
+describe('packFilenameFrom', () => {
+  it('reads the array shape emitted by npm <= 11', () => {
+    const stdout = JSON.stringify([
+      { id: '@sharpee/core@4.3.0', name: '@sharpee/core', filename: 'sharpee-core-4.3.0.tgz' },
+    ]);
+    expect(packFilenameFrom(stdout, '@sharpee/core')).toBe('sharpee-core-4.3.0.tgz');
+  });
+
+  it('reads the package-keyed object shape emitted by npm 12', () => {
+    const stdout = JSON.stringify({
+      '@sharpee/core': {
+        id: '@sharpee/core@4.3.0',
+        name: '@sharpee/core',
+        version: '4.3.0',
+        filename: 'sharpee-core-4.3.0.tgz',
+        files: [],
+      },
+    });
+    expect(packFilenameFrom(stdout, '@sharpee/core')).toBe('sharpee-core-4.3.0.tgz');
+  });
+
+  it('names npm pack and the package when neither shape yields a filename', () => {
+    // The pre-fix failure was a bare "Cannot read properties of undefined (reading 'filename')",
+    // which named neither the tool nor the package (#199).
+    expect(() => packFilenameFrom('{}', '@sharpee/core')).toThrow(
+      /npm pack --json: unexpected output shape — no entry with a filename for @sharpee\/core/,
+    );
+    expect(() => packFilenameFrom('[]', '@sharpee/engine')).toThrow(/for @sharpee\/engine/);
+    expect(() => packFilenameFrom(JSON.stringify([{ name: 'x' }]), '@sharpee/engine')).toThrow(
+      /unexpected output shape/,
+    );
+  });
+
+  it('rejects non-JSON stdout, naming the package', () => {
+    expect(() => packFilenameFrom('npm warn tarball mismatch\n', '@sharpee/stdlib')).toThrow(
+      /npm pack --json: output was not valid JSON .* for @sharpee\/stdlib/,
+    );
+  });
+});
+
 describe('staging-backed generation', () => {
   let root: string;
   let staging: string;
@@ -47,7 +123,13 @@ describe('staging-backed generation', () => {
     writePkg(join(staging, 'core'), '@sharpee/core', []);
     writePkg(join(staging, 'world-model'), '@sharpee/world-model', ['@sharpee/core']);
     writePkg(join(staging, 'engine'), '@sharpee/engine', ['@sharpee/core', '@sharpee/world-model']);
-    writePkg(join(staging, 'transcript-tester'), '@sharpee/transcript-tester', []);
+    // Mirrors the real graph (#201): devkit's deps are mostly covered by any
+    // story's runtime closure, except bootstrap — which no story imports at runtime.
+    writePkg(join(staging, 'bootstrap'), '@sharpee/bootstrap', ['@sharpee/core']);
+    writePkg(join(staging, 'devkit'), '@sharpee/devkit', [
+      '@sharpee/engine',
+      '@sharpee/bootstrap',
+    ]);
     storyPkg = join(root, 'story-package.json');
     writeFileSync(
       storyPkg,
@@ -60,7 +142,7 @@ describe('staging-backed generation', () => {
   it('scanStaging maps @sharpee package names to their staging dirs', () => {
     const map = scanStaging(staging);
     expect(map['@sharpee/engine']).toBe('engine');
-    expect(map['@sharpee/transcript-tester']).toBe('transcript-tester');
+    expect(map['@sharpee/devkit']).toBe('devkit');
   });
 
   it('readSharpeeSeed returns only the @sharpee deps', () => {
@@ -78,16 +160,94 @@ describe('staging-backed generation', () => {
       registryVersion: '0.9.113',
     });
     expect(result.closure).toEqual(['@sharpee/engine']);
-    expect(result.haveTranscriptTester).toBe(true);
+    expect(result.haveHarness).toBe(true);
 
     const pkg = JSON.parse(readFileSync(out, 'utf8'));
     // Only the story's direct @sharpee seed is declared; npm pulls core/world-model transitively.
     expect(pkg.dependencies).toEqual({ '@sharpee/engine': '0.9.113' });
-    // transcript-tester is a dev dep (supplies the bin), not a runtime dep.
-    expect(pkg.devDependencies['@sharpee/transcript-tester']).toBe('0.9.113');
-    expect(pkg.dependencies['@sharpee/transcript-tester']).toBeUndefined();
+    // devkit is a dev dep (supplies the bin), not a runtime dep.
+    expect(pkg.devDependencies['@sharpee/devkit']).toBe('0.9.113');
+    expect(pkg.dependencies['@sharpee/devkit']).toBeUndefined();
     // Third-party deps are NOT declared as @sharpee deps.
     expect(pkg.dependencies.fflate).toBeUndefined();
+  });
+
+  it('declaredSharpeeDeps reports unstaged deps; stagingDepsOf filters them out', () => {
+    writePkg(join(staging, 'engine'), '@sharpee/engine', ['@sharpee/core', '@sharpee/ghost']);
+    const map = scanStaging(staging);
+    expect(declaredSharpeeDeps(staging, map, '@sharpee/engine')).toEqual([
+      '@sharpee/core',
+      '@sharpee/ghost',
+    ]);
+    expect(stagingDepsOf(staging, map, '@sharpee/engine')).toEqual(['@sharpee/core']);
+  });
+
+  // Real-path (rule 13a): drives the production `npm pack` subprocess, no stub.
+  it('generateConsumer (local) vendors devkit\'s own closure as dev deps', () => {
+    const out = join(root, 'consumer-package.json');
+    const vendor = join(root, 'vendor');
+    mkdirSync(vendor, { recursive: true });
+    const result = generateConsumer({
+      mode: 'local',
+      storyPkgPath: storyPkg,
+      stagingDir: staging,
+      vendorDir: vendor,
+      outPkgPath: out,
+    });
+
+    // The story's runtime closure is unchanged — bootstrap is not a runtime dep.
+    expect(result.closure).toEqual(['@sharpee/core', '@sharpee/engine', '@sharpee/world-model']);
+    // bootstrap is vendored solely for devkit (#201: it used to be omitted,
+    // so npm fell through to the registry and failed install with ETARGET).
+    expect(result.devClosure).toEqual(['@sharpee/bootstrap']);
+
+    const pkg = JSON.parse(readFileSync(out, 'utf8'));
+    expect(pkg.dependencies['@sharpee/bootstrap']).toBeUndefined();
+    expect(pkg.devDependencies['@sharpee/bootstrap']).toBe('file:vendor/sharpee-bootstrap-1.0.0.tgz');
+    expect(pkg.devDependencies['@sharpee/devkit']).toBe(
+      'file:vendor/sharpee-devkit-1.0.0.tgz',
+    );
+    // Every file: ref resolves to a tarball that actually exists on disk.
+    const tarballs = new Set(readdirSync(vendor));
+    for (const ref of [
+      ...Object.values(pkg.dependencies as Record<string, string>),
+      ...Object.values(pkg.devDependencies as Record<string, string>),
+    ]) {
+      if (ref.startsWith('file:vendor/')) expect(tarballs.has(ref.slice(12))).toBe(true);
+    }
+    // Runtime closure + bootstrap + devkit, each packed once.
+    expect(tarballs.size).toBe(5);
+  }, 30_000);
+
+  it('generateConsumer (local) throws before packing when a vendored dep is unstaged', () => {
+    // devkit declares a dep that staging does not have: previously this was
+    // silently skipped and only surfaced as an ETARGET at `npm install`.
+    writePkg(join(staging, 'devkit'), '@sharpee/devkit', ['@sharpee/ghost']);
+    const vendor = join(root, 'vendor');
+    mkdirSync(vendor, { recursive: true });
+    expect(() =>
+      generateConsumer({
+        mode: 'local',
+        storyPkgPath: storyPkg,
+        stagingDir: staging,
+        vendorDir: vendor,
+        outPkgPath: join(root, 'consumer-package.json'),
+      }),
+    ).toThrow(/@sharpee\/ghost \(required by @sharpee\/devkit\)/);
+    // "before packing": nothing was written to the vendor dir.
+    expect(readdirSync(vendor)).toEqual([]);
+  });
+
+  it('generateConsumer (registry) reports an empty devClosure — npm resolves transitives', () => {
+    const result = generateConsumer({
+      mode: 'registry',
+      storyPkgPath: storyPkg,
+      stagingDir: staging,
+      vendorDir: join(root, 'vendor'),
+      outPkgPath: join(root, 'consumer-package.json'),
+      registryVersion: '4.3.0',
+    });
+    expect(result.devClosure).toEqual([]);
   });
 
   it('generateConsumer (local) throws when a seed dep is absent from staging', () => {

--- a/packages/devkit/src/consumer-gen.ts
+++ b/packages/devkit/src/consumer-gen.ts
@@ -3,14 +3,27 @@
  * `@sharpee/*` closure either from the local `tsf build --npm` staging (tarballs)
  * or from the registry (version refs).
  *
- * Owner context: @sharpee/devkit `test:npm` command (ADR-180 Phase 2). This is the
- * single, drift-free replacement for the hand-listed dep arrays in npm-test/ and
- * npm-test-dungeo/ and the standalone gen-consumer.mjs in npm-test-familyzoo/.
+ * Owner context: @sharpee/devkit (author tool). devkit's consumer of this is the
+ * standalone-build integration gate, which needs a real installed-from-tarballs
+ * project to run `sharpee build` against.
+ *
+ * ADR-187 R1 keeps repokit and devkit fully separate — each carries its own
+ * implementation, and a hardened repokit feature is **promoted by hand**. This file
+ * is that promotion, taken from `tools/repokit/src/consumer-gen.ts` in session
+ * 51b5f4: it brings across `assertVendoredClosureComplete` (the #201 fix),
+ * npm-12-shaped `npm pack --json` parsing, memoized packing, and dev-closure
+ * vendoring — four fixes the devkit copy had fallen behind on. Do NOT collapse the
+ * two into a shared module: ADR-187 rejects that by name, and repokit is private
+ * and unpublished, so a published devkit could not import it regardless.
  *
  * Public interface:
  *   scanStaging(stagingDir)                  -> name->dir map of @sharpee packages
  *   readSharpeeSeed(storyPkgPath)            -> story's direct @sharpee deps
  *   computeClosure(seed, depsOf)             -> full transitive @sharpee set (pure)
+ *   declaredSharpeeDeps(dir, staging, name)  -> a staged package's declared @sharpee deps
+ *   stagingDepsOf(dir, staging, name)        -> the subset of those that are staged
+ *   assertVendoredClosureComplete(v, depsOf) -> throws on an unvendored @sharpee dep (pure)
+ *   packFilenameFrom(stdout, packageName)    -> tarball filename from `npm pack --json` (pure)
  *   generateConsumer(opts)                   -> writes package.json (+ tarballs for local)
  */
 import { execFileSync } from 'node:child_process';
@@ -18,8 +31,16 @@ import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 const SHARPEE = '@sharpee/';
-/** transcript-tester supplies the `transcript-test` bin (dev-only). */
-const TT = '@sharpee/transcript-tester';
+/**
+ * devkit supplies the `sharpee` bin (dev-only), whose `test` subcommand runs a
+ * project's transcripts and `test --tree` runs its ADR-302 tree.
+ *
+ * This was `@sharpee/transcript-tester` and its `transcript-test` bin. The proof
+ * is stronger through devkit: an outside author runs `sharpee test`, never the
+ * package bin, so the consumer test now exercises the command authors actually
+ * type. It is also what lets the two package bins be retired.
+ */
+const HARNESS = '@sharpee/devkit';
 
 export type StagingMap = Record<string, string>;
 
@@ -65,12 +86,94 @@ export function computeClosure(seed: string[], depsOf: (name: string) => string[
   return closure;
 }
 
-/** `depsOf` backed by the staging map — only deps present in staging are followed. */
-export function stagingDepsOf(stagingDir: string, staging: StagingMap, name: string): string[] {
+/**
+ * Every `@sharpee/*` dependency a staged package declares — including ones that are
+ * **not** themselves staged. Used to detect vendoring gaps; the closure walk uses
+ * `stagingDepsOf` instead.
+ */
+export function declaredSharpeeDeps(
+  stagingDir: string,
+  staging: StagingMap,
+  name: string,
+): string[] {
   const dir = staging[name];
   if (!dir) return [];
   const p = JSON.parse(readFileSync(join(stagingDir, dir, 'package.json'), 'utf8'));
-  return Object.keys(p.dependencies || {}).filter((n) => n.startsWith(SHARPEE) && staging[n]);
+  return Object.keys(p.dependencies || {}).filter((n) => n.startsWith(SHARPEE));
+}
+
+/** `depsOf` backed by the staging map — only deps present in staging are followed. */
+export function stagingDepsOf(stagingDir: string, staging: StagingMap, name: string): string[] {
+  return declaredSharpeeDeps(stagingDir, staging, name).filter((n) => staging[n]);
+}
+
+/**
+ * Assert that every `@sharpee/*` dep declared by a vendored package is itself vendored.
+ *
+ * A `file:` tarball resolves none of its own `@sharpee` deps, so any gap silently falls
+ * through to the public registry — a different, older build — and surfaces far downstream
+ * as an `npm install` `ETARGET` rather than as a generation error (#201). Pure; call it
+ * before packing so a gap costs nothing.
+ *
+ * @param vendored Every package that will be `file:`-referenced, runtime and dev alike.
+ * @param declaredOf Declared `@sharpee` deps of a package, staged or not.
+ * @throws naming each missing package and the vendored package that requires it.
+ */
+export function assertVendoredClosureComplete(
+  vendored: string[],
+  declaredOf: (name: string) => string[],
+): void {
+  const have = new Set(vendored);
+  const gaps = vendored.flatMap((n) =>
+    declaredOf(n)
+      .filter((d) => !have.has(d))
+      .map((d) => `${d} (required by ${n})`),
+  );
+  if (gaps.length) {
+    throw new Error(
+      `@sharpee deps absent from local staging, so npm would resolve them from the registry ` +
+        `instead of the tarballs: ${gaps.join(', ')} — run \`tsf build --npm\` first`,
+    );
+  }
+}
+
+/**
+ * Extract the produced tarball filename from `npm pack --json` stdout.
+ *
+ * The output shape is npm-major-dependent and both are accepted here:
+ *   - npm <= 11 emits an **array** of pack results — `[{ filename, ... }]`
+ *   - npm 12 emits an **object keyed by package name** — `{ "@sharpee/core": { filename, ... } }`
+ *
+ * Only the first entry is read: each call packs exactly one directory.
+ *
+ * @param stdout Raw stdout from `npm pack --json`.
+ * @param packageName Package being packed — named in the error so a shape change is diagnosable.
+ * @returns The tarball filename written into the pack destination.
+ * @throws if stdout is not valid JSON, or if neither shape yields a `filename`.
+ */
+export function packFilenameFrom(stdout: string, packageName: string): string {
+  const fail = (why: string): never => {
+    throw new Error(`npm pack --json: ${why} for ${packageName}`);
+  };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return fail(`output was not valid JSON (got ${JSON.stringify(stdout.slice(0, 120))})`);
+  }
+
+  const entry = Array.isArray(parsed)
+    ? parsed[0]
+    : parsed && typeof parsed === 'object'
+      ? Object.values(parsed as Record<string, unknown>)[0]
+      : undefined;
+
+  const filename = (entry as { filename?: unknown } | undefined)?.filename;
+  if (typeof filename !== 'string' || !filename) {
+    return fail('unexpected output shape — no entry with a filename');
+  }
+  return filename;
 }
 
 export interface GenerateConsumerOptions {
@@ -91,8 +194,14 @@ export interface GenerateConsumerOptions {
 export interface GenerateConsumerResult {
   /** Packages written as runtime deps (full closure in local mode; seed in registry mode). */
   closure: string[];
-  /** true if transcript-tester is available as a dev dep (always true in registry mode). */
-  haveTranscriptTester: boolean;
+  /**
+   * Packages vendored solely to satisfy the harness's own `@sharpee` deps — those
+   * its closure reaches that the runtime closure does not. Local mode only; empty in
+   * registry mode, where npm resolves transitive deps itself.
+   */
+  devClosure: string[];
+  /** true if the harness is available as a dev dep (always true in registry mode). */
+  haveHarness: boolean;
 }
 
 /**
@@ -100,11 +209,15 @@ export interface GenerateConsumerResult {
  *
  * Local mode packs the story's **full transitive `@sharpee` closure** into tarballs
  * and `file:`-refs them — required because `file:` deps do not resolve their own
- * `@sharpee` deps from anywhere. Registry mode declares only the story's **seed**
- * `@sharpee` deps and lets npm resolve transitive deps from the registry, exactly
- * as a real consumer install would (avoids staging-vs-registry graph divergence).
+ * `@sharpee` deps from anywhere. That same reasoning applies to the dev dep, so
+ * the harness's closure is vendored too; whatever it reaches beyond the runtime
+ * closure lands in `devDependencies` rather than overstating the story's runtime
+ * surface (#201). Registry mode declares only the story's **seed** `@sharpee` deps and
+ * lets npm resolve transitive deps from the registry, exactly as a real consumer
+ * install would (avoids staging-vs-registry graph divergence).
  *
- * @throws (local mode) if any seed dep is absent from the local staging.
+ * @throws (local mode) if any seed dep is absent from the local staging, or if any
+ *   vendored package declares an `@sharpee` dep that is not itself vendored.
  */
 export function generateConsumer(opts: GenerateConsumerOptions): GenerateConsumerResult {
   const { mode, storyPkgPath, vendorDir, outPkgPath } = opts;
@@ -113,7 +226,8 @@ export function generateConsumer(opts: GenerateConsumerOptions): GenerateConsume
   const dependencies: Record<string, string> = {};
   const devDependencies: Record<string, string> = { typescript: '^5.0.0' };
   let written: string[];
-  let haveTT: boolean;
+  let devOnly: string[] = [];
+  let haveHarness: boolean;
 
   if (mode === 'local') {
     const staging = scanStaging(opts.stagingDir);
@@ -123,25 +237,50 @@ export function generateConsumer(opts: GenerateConsumerOptions): GenerateConsume
         `story deps absent from local staging: ${missing.join(', ')} — run \`tsf build --npm\` first`,
       );
     }
+    // Memoized: a package reachable from both the runtime and the dev closure is
+    // packed once, not twice.
+    const packed = new Map<string, string>();
     const pack = (name: string): string => {
+      const cached = packed.get(name);
+      if (cached !== undefined) return cached;
       const dir = join(opts.stagingDir, staging[name]);
       const out = execFileSync(
         'npm',
         ['pack', dir, '--pack-destination', vendorDir, '--ignore-scripts', '--json'],
         { encoding: 'utf8' },
       );
-      return JSON.parse(out)[0].filename;
+      const filename = packFilenameFrom(out, name);
+      packed.set(name, filename);
+      return filename;
     };
-    written = [...computeClosure(seed, (n) => stagingDepsOf(opts.stagingDir, staging, n))].sort();
+
+    const depsOf = (n: string) => stagingDepsOf(opts.stagingDir, staging, n);
+    written = [...computeClosure(seed, depsOf)].sort();
+    haveHarness = Boolean(staging[HARNESS]);
+
+    // The harness gets the same closure treatment as the runtime seed: its own
+    // `@sharpee` deps resolve from nowhere once it is a `file:` tarball, so anything
+    // the runtime closure misses (bootstrap, for every story) must be vendored here.
+    const runtime = new Set(written);
+    devOnly = haveHarness
+      ? [...computeClosure([HARNESS], depsOf)].filter((n) => n !== HARNESS && !runtime.has(n)).sort()
+      : [];
+
+    // Before packing: a gap here is an `npm install` ETARGET much later (#201).
+    assertVendoredClosureComplete(
+      [...written, ...devOnly, ...(haveHarness ? [HARNESS] : [])],
+      (n) => declaredSharpeeDeps(opts.stagingDir, staging, n),
+    );
+
     for (const n of written) dependencies[n] = `file:vendor/${pack(n)}`;
-    haveTT = Boolean(staging[TT]);
-    if (haveTT) devDependencies[TT] = `file:vendor/${pack(TT)}`;
+    for (const n of devOnly) devDependencies[n] = `file:vendor/${pack(n)}`;
+    if (haveHarness) devDependencies[HARNESS] = `file:vendor/${pack(HARNESS)}`;
   } else {
     const version = opts.registryVersion || 'latest';
     written = [...seed].sort();
     for (const n of written) dependencies[n] = version;
-    haveTT = true; // transcript-tester is published; npm resolves it from the registry
-    devDependencies[TT] = version;
+    haveHarness = true; // devkit is published; npm resolves it from the registry
+    devDependencies[HARNESS] = version;
   }
 
   writeFileSync(
@@ -161,5 +300,5 @@ export function generateConsumer(opts: GenerateConsumerOptions): GenerateConsume
     ) + '\n',
   );
 
-  return { closure: written, haveTranscriptTester: haveTT };
+  return { closure: written, devClosure: devOnly, haveHarness };
 }

--- a/packages/transcript-tester/package.json
+++ b/packages/transcript-tester/package.json
@@ -4,9 +4,6 @@
   "description": "Transcript-based testing tool for Sharpee interactive fiction",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "transcript-test": "./dist/cli.js"
-  },
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
     "dev": "tsc --watch",

--- a/packages/transcript-tester/src/cli.ts
+++ b/packages/transcript-tester/src/cli.ts
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
 
 /**
- * Transcript Tester CLI
+ * Transcript Tester CLI — dev-only entry point, NO LONGER A PUBLISHED BIN.
  *
- * Usage:
- *   transcript-test <story-path> [transcript-files...]
- *   transcript-test <story-path> --all
- *   transcript-test <story-path> --verbose
+ * The `transcript-test` bin was retired: an author runs `sharpee test` (devkit),
+ * which drives this package as a LIBRARY, and the in-repo path is the bundle
+ * (`dist/cli/sharpee.js --test`). This file survives because it is the only
+ * surface that runs a story through Node's real ESM resolver rather than through
+ * the bundle's esbuild aliases — which is how the cloak-of-darkness
+ * type-imported-as-value defect was found (#225).
+ *
+ * Usage (run the file directly; there is no installed command):
+ *   node packages/transcript-tester/dist/cli.js <story-path> [transcript-files...]
+ *   node packages/transcript-tester/dist/cli.js <story-path> --all
  */
 
 import * as path from 'path';
@@ -109,9 +115,12 @@ function printHelp(): void {
   console.log(`
 Transcript Tester - Test Sharpee stories with transcript files
 
+This is a dev-only entry point. There is no installed \`transcript-test\` command:
+authors run \`sharpee test\` and the in-repo path is \`dist/cli/sharpee.js --test\`.
+
 Usage:
-  transcript-test <story-path> [transcript-files...] [options]
-  transcript-test <story-path> --play
+  node packages/transcript-tester/dist/cli.js <story-path> [transcript-files...] [options]
+  node packages/transcript-tester/dist/cli.js <story-path> --play
 
 Arguments:
   story-path         Path to the story directory (e.g., stories/dungeo)
@@ -131,13 +140,13 @@ Options:
   -o, --output-dir <dir> Write timestamped results to directory (JSON + text report)
   -h, --help             Show this help message
 
-Examples:
-  transcript-test stories/dungeo --play
-  transcript-test stories/dungeo tests/navigation.transcript
-  transcript-test stories/dungeo --all
-  transcript-test stories/dungeo tests/*.transcript --verbose
-  transcript-test stories/dungeo --all -o test-results
-  transcript-test stories/dungeo --chain tests/setup.transcript tests/puzzle.transcript
+Examples (CLI="node packages/transcript-tester/dist/cli.js"):
+  $CLI stories/dungeo --play
+  $CLI stories/dungeo tests/navigation.transcript
+  $CLI stories/dungeo --all
+  $CLI stories/dungeo tests/*.transcript --verbose
+  $CLI stories/dungeo --all -o test-results
+  $CLI stories/dungeo --chain tests/setup.transcript tests/puzzle.transcript
 `);
 }
 

--- a/packages/transcript-tester/src/index.ts
+++ b/packages/transcript-tester/src/index.ts
@@ -3,8 +3,9 @@
  *
  * Transcript-based testing for Sharpee interactive fiction stories.
  *
- * Usage:
- *   npx transcript-test <story-path> [transcripts...]
+ * Usage: as a LIBRARY. The `transcript-test` bin is retired — an author runs
+ * `sharpee test` (devkit), which imports this package, and the in-repo path is
+ * the bundle's `--test`.
  *
  * See ADR-073 for format specification.
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       '@sharpee/bootstrap':
         specifier: workspace:*
         version: link:../bootstrap
+      '@sharpee/branch-tester':
+        specifier: workspace:*
+        version: link:../branch-tester
       '@sharpee/chord':
         specifier: workspace:*
         version: link:../chord

--- a/scripts/bundle-entry.js
+++ b/scripts/bundle-entry.js
@@ -648,24 +648,29 @@ Examples:
     // and its replayed prefix would diverge from the one its first child saw.
     // The seed the first boot actually resolved is therefore remembered and
     // re-pinned, and the announcement is made once.
-    const bootedSeeds = new Map();
-    const freshGameForRoot = async (root) => {
-      const config = root.transcript.config || {};
-      const remembered = bootedSeeds.get(root.stem);
-      const resolved = remembered ?? resolveSeed(root.transcript.seed);
-      const game = loadStoryAndCreateGame(
-        options.storyPath,
-        root.transcript.header && root.transcript.header.entry,
-        resolved.seed,
-        config.channels || []
-      );
-      if (!remembered) {
-        const seed = game.engine.getMasterSeed();
-        bootedSeeds.set(root.stem, { seed, source: resolved.source });
-        console.log(`Seed: ${seed} (${resolved.source})`);
-      }
-      return game;
-    };
+    // The re-pin rule itself lives in @sharpee/branch-tester's
+    // `createRootGameFactory` — this was a hand-copy of it, and the copy is why
+    // the rule had to be rediscovered when only the package side was updated.
+    // What stays here is what is genuinely the CLI's: `resolveSeed`, which lets
+    // `--seed` and `--vary` outrank the transcript's own pin. It runs inside
+    // `load`, so an override wins on the first boot AND on every re-boot.
+    let lastSource = 'clock';
+    const freshGameForRoot = branchTester.createRootGameFactory({
+      load: (spec) => {
+        const resolved = resolveSeed(spec.seed);
+        lastSource = resolved.source;
+        return loadStoryAndCreateGame(
+          options.storyPath,
+          spec.entry,
+          resolved.seed,
+          spec.channels
+        );
+      },
+      masterSeedOf: (game) => game.engine.getMasterSeed(),
+      // `load` runs immediately before this, awaited, so `lastSource` is that
+      // boot's. Announced once per root, not once per fork below it.
+      onFirstBoot: (stem, seed) => console.log(`Seed: ${seed} (${lastSource})`)
+    });
 
     const run = await branchTester.runTree(tree, freshGameForRoot, {
       verbose: options.verbose,

--- a/stories/cloak-of-darkness/src/index.ts
+++ b/stories/cloak-of-darkness/src/index.ts
@@ -10,7 +10,7 @@
  * (which would disturb the sawdust).
  */
 
-import { Story, StoryConfig } from '@sharpee/engine';
+import type { Story, StoryConfig } from '@sharpee/engine';
 import type { GameEngine, CustomVocabulary } from '@sharpee/engine';
 import type { Parser } from '@sharpee/parser-en-us';
 // @ts-ignore - lang-en-us types not available yet
@@ -26,10 +26,12 @@ import {
   SupporterTrait,
   SceneryTrait,
   ReadableTrait,
-  IScopeRule,
   EntityType,
   Direction
 } from '@sharpee/world-model';
+// `IScopeRule` is type-only: it has no runtime export, so a value import survives
+// the ESM emit and Node rejects the module. Only the esbuild bundle hid this.
+import type { IScopeRule } from '@sharpee/world-model';
 import type { IGameEvent, Effect, WorldQuery } from '@sharpee/event-processor';
 
 /**

--- a/tools/repokit/src/commands/test-npm.ts
+++ b/tools/repokit/src/commands/test-npm.ts
@@ -110,7 +110,7 @@ export function runTestNpm(opts: TestNpmOptions): TestNpmResult {
     // 1. Generate the consumer package.json (+ vendor tarballs for local mode).
     const vendor = join(tmp, 'vendor');
     mkdirSync(vendor, { recursive: true });
-    const { closure, devClosure, haveTranscriptTester } = generateConsumer({
+    const { closure, devClosure, haveHarness } = generateConsumer({
       mode,
       storyPkgPath,
       stagingDir,
@@ -121,12 +121,12 @@ export function runTestNpm(opts: TestNpmOptions): TestNpmResult {
     log(`closure (${closure.length}): ${closure.map((n) => n.replace('@sharpee/', '')).join(', ')}`);
     if (devClosure.length) {
       log(
-        `dev closure (${devClosure.length}, transcript-tester only): ` +
+        `dev closure (${devClosure.length}, devkit only): ` +
           devClosure.map((n) => n.replace('@sharpee/', '')).join(', '),
       );
     }
-    if (!haveTranscriptTester) {
-      throw new Error('@sharpee/transcript-tester missing from staging — cannot run transcripts');
+    if (!haveHarness) {
+      throw new Error('@sharpee/devkit missing from staging — cannot run transcripts');
     }
 
     // 2. Copy story src (minus platform entry points) + tsconfig.
@@ -161,7 +161,7 @@ export function runTestNpm(opts: TestNpmOptions): TestNpmResult {
     const rel = transcripts.map((t) => join('transcripts', basename(t)));
     if (opts.chain) {
       try {
-        run('npx', ['transcript-test', '.', '--chain', ...rel]);
+        run('npx', ['sharpee', 'test', '.', '--chain', ...rel]);
         return { passed: transcripts.length, failed: 0, failures: [], ran: true };
       } catch {
         return { passed: 0, failed: transcripts.length, failures: ['chain'], ran: true };
@@ -171,7 +171,7 @@ export function runTestNpm(opts: TestNpmOptions): TestNpmResult {
     const failures: string[] = [];
     for (const r of rel) {
       try {
-        run('npx', ['transcript-test', '.', r]);
+        run('npx', ['sharpee', 'test', '.', r]);
         passed++;
       } catch {
         failures.push(basename(r, '.transcript'));

--- a/tools/repokit/src/commands/test-npm.ts
+++ b/tools/repokit/src/commands/test-npm.ts
@@ -53,6 +53,15 @@ export interface TestNpmOptions {
   transcripts?: string;
   /** Run transcripts as one stateful chain (dungeo walkthroughs) instead of per-file. */
   chain?: boolean;
+  /**
+   * Run the transcripts as an ADR-302 TREE (`sharpee test --tree`) instead of as
+   * independent files. Mutually exclusive with `chain`, which D10 retires for trees.
+   *
+   * This is the only path that proves the tree harness survives an npm install: a
+   * tree run boots a fresh game per root AND per fork, replays ancestry, and
+   * re-pins seeds across boots — none of which the per-file path exercises.
+   */
+  tree?: boolean;
   /** Compile only; skip transcript execution. */
   quick?: boolean;
   /** Registry version/range for @sharpee deps (registry mode; default 'latest'). */
@@ -156,9 +165,21 @@ export function runTestNpm(opts: TestNpmOptions): TestNpmResult {
       return { passed: 0, failed: 0, failures: [], ran: false };
     }
 
-    // 5. Run transcripts (chain = one stateful invocation; else per-file count).
+    // 5. Run transcripts (tree = one whole-tree invocation; chain = one stateful
+    // invocation; else per-file count).
     log('--- transcripts ---');
     const rel = transcripts.map((t) => join('transcripts', basename(t)));
+    if (opts.tree) {
+      // The whole tree is one invocation by construction (D11: assembled and
+      // validated before anything runs), so it is pass-or-fail as a unit — a
+      // per-file tally would misreport a cascade as several failures (D13).
+      try {
+        run('npx', ['sharpee', 'test', '.', '--tree', ...rel]);
+        return { passed: transcripts.length, failed: 0, failures: [], ran: true };
+      } catch {
+        return { passed: 0, failed: transcripts.length, failures: ['tree'], ran: true };
+      }
+    }
     if (opts.chain) {
       try {
         run('npx', ['sharpee', 'test', '.', '--chain', ...rel]);
@@ -200,6 +221,7 @@ function parseTestNpmArgs(args: string[]): TestNpmOptions {
     if (a === '--local') opts.mode = 'local';
     else if (a === '--registry') opts.mode = 'registry';
     else if (a === '--chain') opts.chain = true;
+    else if (a === '--tree') opts.tree = true;
     else if (a === '--quick') opts.quick = true;
     else if (a === '--keep') opts.keep = true;
     else if (a === '--version') opts.registryVersion = args[++i];
@@ -211,6 +233,9 @@ function parseTestNpmArgs(args: string[]): TestNpmOptions {
     i++;
   }
   if (!opts.location) throw new Error('test:npm requires a story <location>');
+  // ADR-302 D10 retires --chain for trees; honouring one silently would hide
+  // which run model actually produced the result.
+  if (opts.tree && opts.chain) throw new Error('--tree and --chain are mutually exclusive');
   return opts;
 }
 

--- a/tools/repokit/src/consumer-gen.test.ts
+++ b/tools/repokit/src/consumer-gen.test.ts
@@ -50,18 +50,18 @@ describe('assertVendoredClosureComplete', () => {
   });
 
   it('throws naming the unvendored dep and the package that requires it', () => {
-    // The #201 shape: transcript-tester is vendored, its bootstrap dep is not, so npm
+    // The #201 shape: devkit is vendored, its bootstrap dep is not, so npm
     // would resolve bootstrap from the registry and fail install with ETARGET.
     const declared: Record<string, string[]> = {
-      '@sharpee/transcript-tester': ['@sharpee/core', '@sharpee/bootstrap'],
+      '@sharpee/devkit': ['@sharpee/core', '@sharpee/bootstrap'],
       '@sharpee/core': [],
     };
     expect(() =>
       assertVendoredClosureComplete(
-        ['@sharpee/transcript-tester', '@sharpee/core'],
+        ['@sharpee/devkit', '@sharpee/core'],
         (n) => declared[n] ?? [],
       ),
-    ).toThrow(/@sharpee\/bootstrap \(required by @sharpee\/transcript-tester\)/);
+    ).toThrow(/@sharpee\/bootstrap \(required by @sharpee\/devkit\)/);
   });
 });
 
@@ -123,10 +123,10 @@ describe('staging-backed generation', () => {
     writePkg(join(staging, 'core'), '@sharpee/core', []);
     writePkg(join(staging, 'world-model'), '@sharpee/world-model', ['@sharpee/core']);
     writePkg(join(staging, 'engine'), '@sharpee/engine', ['@sharpee/core', '@sharpee/world-model']);
-    // Mirrors the real graph (#201): transcript-tester's deps are mostly covered by any
+    // Mirrors the real graph (#201): devkit's deps are mostly covered by any
     // story's runtime closure, except bootstrap — which no story imports at runtime.
     writePkg(join(staging, 'bootstrap'), '@sharpee/bootstrap', ['@sharpee/core']);
-    writePkg(join(staging, 'transcript-tester'), '@sharpee/transcript-tester', [
+    writePkg(join(staging, 'devkit'), '@sharpee/devkit', [
       '@sharpee/engine',
       '@sharpee/bootstrap',
     ]);
@@ -142,7 +142,7 @@ describe('staging-backed generation', () => {
   it('scanStaging maps @sharpee package names to their staging dirs', () => {
     const map = scanStaging(staging);
     expect(map['@sharpee/engine']).toBe('engine');
-    expect(map['@sharpee/transcript-tester']).toBe('transcript-tester');
+    expect(map['@sharpee/devkit']).toBe('devkit');
   });
 
   it('readSharpeeSeed returns only the @sharpee deps', () => {
@@ -160,14 +160,14 @@ describe('staging-backed generation', () => {
       registryVersion: '0.9.113',
     });
     expect(result.closure).toEqual(['@sharpee/engine']);
-    expect(result.haveTranscriptTester).toBe(true);
+    expect(result.haveHarness).toBe(true);
 
     const pkg = JSON.parse(readFileSync(out, 'utf8'));
     // Only the story's direct @sharpee seed is declared; npm pulls core/world-model transitively.
     expect(pkg.dependencies).toEqual({ '@sharpee/engine': '0.9.113' });
-    // transcript-tester is a dev dep (supplies the bin), not a runtime dep.
-    expect(pkg.devDependencies['@sharpee/transcript-tester']).toBe('0.9.113');
-    expect(pkg.dependencies['@sharpee/transcript-tester']).toBeUndefined();
+    // devkit is a dev dep (supplies the bin), not a runtime dep.
+    expect(pkg.devDependencies['@sharpee/devkit']).toBe('0.9.113');
+    expect(pkg.dependencies['@sharpee/devkit']).toBeUndefined();
     // Third-party deps are NOT declared as @sharpee deps.
     expect(pkg.dependencies.fflate).toBeUndefined();
   });
@@ -183,7 +183,7 @@ describe('staging-backed generation', () => {
   });
 
   // Real-path (rule 13a): drives the production `npm pack` subprocess, no stub.
-  it('generateConsumer (local) vendors transcript-tester\'s own closure as dev deps', () => {
+  it('generateConsumer (local) vendors devkit\'s own closure as dev deps', () => {
     const out = join(root, 'consumer-package.json');
     const vendor = join(root, 'vendor');
     mkdirSync(vendor, { recursive: true });
@@ -197,15 +197,15 @@ describe('staging-backed generation', () => {
 
     // The story's runtime closure is unchanged — bootstrap is not a runtime dep.
     expect(result.closure).toEqual(['@sharpee/core', '@sharpee/engine', '@sharpee/world-model']);
-    // bootstrap is vendored solely for transcript-tester (#201: it used to be omitted,
+    // bootstrap is vendored solely for devkit (#201: it used to be omitted,
     // so npm fell through to the registry and failed install with ETARGET).
     expect(result.devClosure).toEqual(['@sharpee/bootstrap']);
 
     const pkg = JSON.parse(readFileSync(out, 'utf8'));
     expect(pkg.dependencies['@sharpee/bootstrap']).toBeUndefined();
     expect(pkg.devDependencies['@sharpee/bootstrap']).toBe('file:vendor/sharpee-bootstrap-1.0.0.tgz');
-    expect(pkg.devDependencies['@sharpee/transcript-tester']).toBe(
-      'file:vendor/sharpee-transcript-tester-1.0.0.tgz',
+    expect(pkg.devDependencies['@sharpee/devkit']).toBe(
+      'file:vendor/sharpee-devkit-1.0.0.tgz',
     );
     // Every file: ref resolves to a tarball that actually exists on disk.
     const tarballs = new Set(readdirSync(vendor));
@@ -215,14 +215,14 @@ describe('staging-backed generation', () => {
     ]) {
       if (ref.startsWith('file:vendor/')) expect(tarballs.has(ref.slice(12))).toBe(true);
     }
-    // Runtime closure + bootstrap + transcript-tester, each packed once.
+    // Runtime closure + bootstrap + devkit, each packed once.
     expect(tarballs.size).toBe(5);
   }, 30_000);
 
   it('generateConsumer (local) throws before packing when a vendored dep is unstaged', () => {
-    // transcript-tester declares a dep that staging does not have: previously this was
+    // devkit declares a dep that staging does not have: previously this was
     // silently skipped and only surfaced as an ETARGET at `npm install`.
-    writePkg(join(staging, 'transcript-tester'), '@sharpee/transcript-tester', ['@sharpee/ghost']);
+    writePkg(join(staging, 'devkit'), '@sharpee/devkit', ['@sharpee/ghost']);
     const vendor = join(root, 'vendor');
     mkdirSync(vendor, { recursive: true });
     expect(() =>
@@ -233,7 +233,7 @@ describe('staging-backed generation', () => {
         vendorDir: vendor,
         outPkgPath: join(root, 'consumer-package.json'),
       }),
-    ).toThrow(/@sharpee\/ghost \(required by @sharpee\/transcript-tester\)/);
+    ).toThrow(/@sharpee\/ghost \(required by @sharpee\/devkit\)/);
     // "before packing": nothing was written to the vendor dir.
     expect(readdirSync(vendor)).toEqual([]);
   });

--- a/tools/repokit/src/consumer-gen.ts
+++ b/tools/repokit/src/consumer-gen.ts
@@ -22,8 +22,16 @@ import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 const SHARPEE = '@sharpee/';
-/** transcript-tester supplies the `transcript-test` bin (dev-only). */
-const TT = '@sharpee/transcript-tester';
+/**
+ * devkit supplies the `sharpee` bin (dev-only), whose `test` subcommand runs a
+ * project's transcripts and `test --tree` runs its ADR-302 tree.
+ *
+ * This was `@sharpee/transcript-tester` and its `transcript-test` bin. The proof
+ * is stronger through devkit: an outside author runs `sharpee test`, never the
+ * package bin, so the consumer test now exercises the command authors actually
+ * type. It is also what lets the two package bins be retired.
+ */
+const HARNESS = '@sharpee/devkit';
 
 export type StagingMap = Record<string, string>;
 
@@ -178,13 +186,13 @@ export interface GenerateConsumerResult {
   /** Packages written as runtime deps (full closure in local mode; seed in registry mode). */
   closure: string[];
   /**
-   * Packages vendored solely to satisfy transcript-tester's own `@sharpee` deps — those
+   * Packages vendored solely to satisfy the harness's own `@sharpee` deps — those
    * its closure reaches that the runtime closure does not. Local mode only; empty in
    * registry mode, where npm resolves transitive deps itself.
    */
   devClosure: string[];
-  /** true if transcript-tester is available as a dev dep (always true in registry mode). */
-  haveTranscriptTester: boolean;
+  /** true if the harness is available as a dev dep (always true in registry mode). */
+  haveHarness: boolean;
 }
 
 /**
@@ -193,7 +201,7 @@ export interface GenerateConsumerResult {
  * Local mode packs the story's **full transitive `@sharpee` closure** into tarballs
  * and `file:`-refs them — required because `file:` deps do not resolve their own
  * `@sharpee` deps from anywhere. That same reasoning applies to the dev dep, so
- * transcript-tester's closure is vendored too; whatever it reaches beyond the runtime
+ * the harness's closure is vendored too; whatever it reaches beyond the runtime
  * closure lands in `devDependencies` rather than overstating the story's runtime
  * surface (#201). Registry mode declares only the story's **seed** `@sharpee` deps and
  * lets npm resolve transitive deps from the registry, exactly as a real consumer
@@ -210,7 +218,7 @@ export function generateConsumer(opts: GenerateConsumerOptions): GenerateConsume
   const devDependencies: Record<string, string> = { typescript: '^5.0.0' };
   let written: string[];
   let devOnly: string[] = [];
-  let haveTT: boolean;
+  let haveHarness: boolean;
 
   if (mode === 'local') {
     const staging = scanStaging(opts.stagingDir);
@@ -239,31 +247,31 @@ export function generateConsumer(opts: GenerateConsumerOptions): GenerateConsume
 
     const depsOf = (n: string) => stagingDepsOf(opts.stagingDir, staging, n);
     written = [...computeClosure(seed, depsOf)].sort();
-    haveTT = Boolean(staging[TT]);
+    haveHarness = Boolean(staging[HARNESS]);
 
-    // transcript-tester gets the same closure treatment as the runtime seed: its own
+    // The harness gets the same closure treatment as the runtime seed: its own
     // `@sharpee` deps resolve from nowhere once it is a `file:` tarball, so anything
     // the runtime closure misses (bootstrap, for every story) must be vendored here.
     const runtime = new Set(written);
-    devOnly = haveTT
-      ? [...computeClosure([TT], depsOf)].filter((n) => n !== TT && !runtime.has(n)).sort()
+    devOnly = haveHarness
+      ? [...computeClosure([HARNESS], depsOf)].filter((n) => n !== HARNESS && !runtime.has(n)).sort()
       : [];
 
     // Before packing: a gap here is an `npm install` ETARGET much later (#201).
     assertVendoredClosureComplete(
-      [...written, ...devOnly, ...(haveTT ? [TT] : [])],
+      [...written, ...devOnly, ...(haveHarness ? [HARNESS] : [])],
       (n) => declaredSharpeeDeps(opts.stagingDir, staging, n),
     );
 
     for (const n of written) dependencies[n] = `file:vendor/${pack(n)}`;
     for (const n of devOnly) devDependencies[n] = `file:vendor/${pack(n)}`;
-    if (haveTT) devDependencies[TT] = `file:vendor/${pack(TT)}`;
+    if (haveHarness) devDependencies[HARNESS] = `file:vendor/${pack(HARNESS)}`;
   } else {
     const version = opts.registryVersion || 'latest';
     written = [...seed].sort();
     for (const n of written) dependencies[n] = version;
-    haveTT = true; // transcript-tester is published; npm resolves it from the registry
-    devDependencies[TT] = version;
+    haveHarness = true; // devkit is published; npm resolves it from the registry
+    devDependencies[HARNESS] = version;
   }
 
   writeFileSync(
@@ -283,5 +291,5 @@ export function generateConsumer(opts: GenerateConsumerOptions): GenerateConsume
     ) + '\n',
   );
 
-  return { closure: written, devClosure: devOnly, haveTranscriptTester: haveTT };
+  return { closure: written, devClosure: devOnly, haveHarness };
 }


### PR DESCRIPTION
Retires the `transcript-test` and `branch-test` bins, gives the ADR-302 tree harness an author-facing entry point in their place, and folds the ADR-303 D6 widening into ADR-131.

Three independently revertible commits.

## `56d76928` — ADR-131 gains the ADR-303 D6 widening

Replaces the SCOPE QUESTION OPENED note with SCOPE WIDENED and writes the decision into the body: two modes over one walk (baseline vs reachability), the static dead-end/one-way analysis moving to the IDE, four new consequences. The earlier "widening would replace its premise" objection is **retracted in place rather than deleted**, because ADR-303 D5's probe replays the story's own answer key and so solves no puzzle — the *Starting Point* exclusion survives intact.

Landed **ahead of its trigger**: D6 names whoever accepts ADR-303 as the owner, and ADR-303 is still DRAFT. Both files say so, and D6's now-false "ADR-131 stands unamended until that lands" sentence is corrected with a dated note. Accepting ADR-303 to satisfy the trigger was rejected — it scored 7/17, and flipping a Status line to unlock a doc edit is the rot pattern rather than a fix for it.

## `86e664f9` — the retirement

**`createRootGameFactory`** (`packages/branch-tester/src/game-factory.ts`) is now the one implementation of ADR-302 D17's re-pin rule: a root booted at every fork below it must land on the same master seed. `freshGameForRoot` had been hand-copied into `cli.ts` and `scripts/bundle-entry.js`, and the copies had already drifted on which field the seed is read from (`transcript.seed` vs `config.seeds[0]` — latent, since the parser mirrors the singular form into both). All three callers share it; the bundle keeps only `resolveSeed`, which is genuinely the CLI's, and now applies `--seed`/`--vary` precedence on re-boots as well as first boots.

**`sharpee test --tree`** (`packages/devkit/src/commands/test-tree.ts`) drives the tree over devkit's own `loadAuthorGame`, so Chord `.story` projects work — which the `branch-test` bin never could, since Chord compilation lives in the bundle.

**`test:npm` re-pointed** at `npx sharpee test`. The proof is stronger than what it replaced: an author runs `sharpee test`, never the bin, so the consumer test now exercises the command that actually exists in their world.

**Two guards exit 2 rather than silently picking a behaviour.** `--tree --chain` (D10 retires `--chain`), and `--tree --json` — the ADR-277 record stream carries no parentage, no `unreached` and no replay markers, so a tree emitted through it would be well-formed and wrong. **That guard should be deleted in the same change that lands the IDE Testing wire.**

**`stories/cloak-of-darkness`**: `IScopeRule`, `Story` and `StoryConfig` were imported in value position though all three are type-only, so the ESM emit kept the bindings and Node rejected the module. That was the whole of #225, whose headline ("cannot load any story") was false — dungeo always loaded.

## `6f890e56` — the tree's npm proof, and the #232 promotion

`sharpee test --tree` had been verified only in-repo, on the side of the workspace-symlink line where #225's class of defect is invisible. `branch-stories/tree-npm-fixture/` is the smallest module story forming a tree (one root, **two** children — a single child replays nothing and would not exercise D17), and `test:npm` gained `--tree`. It caught a real defect on its first run: the fixture had no `createStory()` export and failed the ADR-248 factory contract.

**#232 is resolved by promotion, not deletion, and the filing was wrong.** devkit's `consumer-gen` is not dead (`standalone-build.test.ts` uses it), and ADR-187 R1 rejects the shared module by name — repokit is the proving ground, hardened features are ported to devkit by hand. A re-export was impossible regardless, since repokit is `private` and never published. The one true claim was that devkit had fallen four fixes behind, so repokit's version was walked across.

## Verification

| Check | Result |
|---|---|
| Fernhill tree, bundle and devkit | `22 passed`, `552 commands (518 authored + 34 replayed)` — matches pre-change |
| Dungeo v1 walkthrough chain | `952 passed` in 17 transcripts |
| Tree through a real npm install | `3 passed`, `4 commands (3 authored + 1 replayed)` |
| Flat through a real npm install | `RESULTS: 1 passing, 0 failures` |
| Seed announcements / `--seed 99` override | 5 per-root lines; override reaches all five |
| branch-tester / transcript-tester | 360 / 253 |
| repokit / devkit | 81 / 129 |

## Known, not caused here

- devkit's 2 `browser-core-build` failures hardcode `stories/fernhill/fernhill.story`; ADR-302 D16 moved Fernhill to `branch-stories/`.
- `test:npm` is red for familyzoo (#224) and cloak (stale `@sharpee/text-service` imports), which is why dungeo and the new fixture are the proof corpora.
- **Type-only symbols imported in value position are a repo-wide pattern**: `stories/concealment-test/src/index.ts:19` is identical to the cloak bug. Only cloak is fixed; a sweep is owed.

Closes #225. Closes #232. Filed #231.
