### PR TITLE
docs: finalize session ed3730 (5.0.0 shipped, ADR-309 closed)

### DIFF
--- a/docs/context/session-20260810-1535-feat-testing-tab-embed.md
+++ b/docs/context/session-20260810-1535-feat-testing-tab-embed.md
@@ -166,16 +166,42 @@ ProjectArtifacts + 3 Swift test files, 4 ADRs, functional-logic doc, plan,
   `presentFixFailure` + wiring, `SpanText` comment,
   `StoryHeaderIFID.insertion` + tests) — confirm-first per CLAUDE.md.
 
+## Ship (evening)
+- **Sharpee 5.0.0**: `tsf version 5.0.0` across 33 packages, plus the trap
+  the last bump hit — `ENGINE_VERSION` and dungeo's stamped constants
+  re-stamped so the publish workflow's `git diff --exit-code` guard passes
+  on its own build output. Chord language stays 3.0.0, Chord Writer 1.0.0;
+  the website reads its badge live from `packages/sharpee/package.json`.
+- **PR #257 merged** (`31ef79b2` → `fe5b4e94`): 168 files, +3,190/−12,369 —
+  the ADR-307 cutover, ADR-309 implementation, and the version bump.
+- **Publish dry run GREEN** (run 31440383661): every package built at
+  5.0.0, stamping guard passed, artifacts built, Validate passed, Publish
+  (dry run) passed, real Publish correctly skipped.
+- **PR #258 merged** (`2f4d91ab` → `87a00365`) — the two items #257 left
+  open, both closed on David's word:
+  - **Quick-fix path retired** (Phase 3's held deletion): ProblemsView's
+    `fixes` registry + button + `fixClicked` + `onFix`, MainWindow's
+    `applyProblemFix`/`presentFixFailure`/wiring,
+    `StoryHeaderIFID.insertion` + `Insertion`. Two fixtures that used the
+    retired diagnostic as sample data retargeted to a generic
+    block-spanning warning. IDE **480 passing, 0 failures** (−12).
+  - **SonarCloud gate cleared**: all three "reliability bugs" were S2871
+    (bare `.sort()`). Sonar's `localeCompare` advice would have been a REAL
+    bug — one sort orders a persisted wire document's keys, the other picks
+    which story a directory resolves to, and locale collation would make
+    both machine-dependent. Fixed with explicit code-unit comparators.
+    **SonarCloud PASS on #258** (it failed on #257).
+
 ## Session Metadata
-- **Status**: IN PROGRESS. ADR-307 plan DONE (all six phases, cutover
-  landed). ADR-309 Phases 1–3 landed the same session, with ONE item held
-  for David: the Swift dead-code deletion. Uncommitted: everything above
-  plus the prior session's carry-overs (`.gitignore`, `project.yml`, prior
-  session/plan edits). Nothing has been committed today.
-- **Open items**: (1) **Swift dead-code deletion** — ADR-309 Phase 3's held
-  item, needs David's yes/no. (2) **`sharpee ifid`** — recommend keeping as
-  a raw generate/validate utility; David's call (the website's install page
-  still lists it, pending that). (3) ADR-308 open-questions interview
+- **Status**: COMPLETE. ADR-307 plan DONE (all six phases). ADR-309 DONE
+  (all three phases + the held deletion). Sharpee 5.0.0 shipped to `main`
+  via PRs #257 and #258; publish dry run green; SonarCloud green on #258.
+  Working tree clean except `scripts/clodpod.sh`, which stays untracked by
+  design.
+- **Open items**: (1) ~~Swift dead-code deletion~~ — DONE in PR #258.
+  (2) **`sharpee ifid`** — recommend keeping as a raw generate/validate
+  utility; David's call (the website's install page still lists it,
+  pending that). (3) ADR-308 open-questions interview
   (re-offer when navigation work starts). (4) Splice gesture chrome still
   unruled (carried). (5) Module projects have no test path post-cutover
   (ADR-307 ruling C consequence). (6) branch-tester's runner still carries

--- a/docs/work/ifid/plan-20260810-adr-309-tool-owned-ifid.md
+++ b/docs/work/ifid/plan-20260810-adr-309-tool-owned-ifid.md
@@ -1,8 +1,9 @@
 # Session Plan: ADR-309 Tool-Owned IFID
 
 **Created**: 2026-08-10
-**Plan Status**: ACTIVE — Phases 1 and 2 DONE; Phase 3 DONE except one
-held item (the Swift dead-code removal awaits David's delete confirmation).
+**Plan Status**: DONE (2026-08-10, session ed3730 — all three phases,
+including the held Swift dead-code removal, which David closed the same
+evening and which landed in PR #258 alongside the SonarCloud sort fix).
 **Overall scope**: Implement ADR-309 end to end — the `{story-name}.config.json`
 sidecar becomes the canonical home of a story's IFID; `sharpee init` and Chord
 Writer's Create Story mint it and write the config before the author types a
@@ -332,7 +333,12 @@ publish-time refusal, now unreachable-by-construction for tool-built stories).
     build was running in parallel); classified by isolation (4/4 green,
     0.9s) and confirmed by a clean full run (492/0). Not in this change
     set — that suite tests file-watcher reload, untouched here.
-- **Held for David**: the Swift dead-code removal —
+- **Held item — CLOSED** (PR #258, `2f4d91ab`): the Swift dead-code removal
+  landed with the whole quick-fix path (registry, button, `fixClicked`,
+  `onFix`, `applyProblemFix`, `presentFixFailure`, wiring,
+  `StoryHeaderIFID.insertion` + `Insertion`), two fixtures retargeted off
+  the retired diagnostic, and IDE **480 passing, 0 failures**. Originally
+  scoped as —
   `ProblemsView.fixes["analysis.missing-ifid"]` (~line 33),
   `MainWindow.applyProblemFix` (~753) + `presentFixFailure` (~770) + the
   wiring (~359), `SpanText.swift`'s example comment (~27), and


### PR DESCRIPTION
Session record and plan status only — no code.

- Session summary records the 5.0.0 bump, PRs #257/#258, and the green publish dry run.
- ADR-309 plan flipped to DONE; its held item (the Swift dead-code removal) closed in #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012myBrJ2H6X2YXEmoiHAWvi