### PR TITLE
docs(devkit): record that `sharpee ifid` stays, and what it is not

### DIFF
--- a/docs/work/ifid/plan-20260810-adr-309-tool-owned-ifid.md
+++ b/docs/work/ifid/plan-20260810-adr-309-tool-owned-ifid.md
@@ -113,9 +113,12 @@ publish-time refusal, now unreachable-by-construction for tool-built stories).
   story-config, AC-1 scaffold, publish adopt/broken/no-identity, compose
   broken read-only, 3 build entry-point tests closing
   mutation-verification's warning); tsc clean; dist rebuilt;
-  `tsf build --npm` green. `sharpee ifid`: RECOMMEND KEEP as raw
-  generate/validate utility (no story-file coupling; the new module uses
-  the same core primitives) — David's call, flagged in the phase report.
+  `tsf build --npm` green. `sharpee ifid`: **KEPT — David's ruling
+  2026-08-10, "stays if anyone wants to use it."** A raw utility over the
+  identifier format, no story-file coupling — which is what separates it
+  from the Problems quick-fix that did retire. Its text needed no change
+  (it never told authors to hand-edit a header); a header note now records
+  the ruling and states it is not the remedy for a missing IFID.
 - **Deletions**: none performed.
 
 ### Phase 2: Chord Writer (IDE) — Create Story, reconcile-on-save, broken-config surfacing

--- a/packages/devkit/src/standalone/ifid.ts
+++ b/packages/devkit/src/standalone/ifid.ts
@@ -1,5 +1,15 @@
-// packages/sharpee/src/cli/ifid.ts
-// IFID CLI commands
+// ifid.ts — `sharpee ifid`: generate and validate Treaty of Babel identifiers.
+//
+// KEPT through ADR-309's cleanup by David's ruling (2026-08-10): "sharpee ifid
+// stays if anyone wants to use it." It is a raw utility over the identifier
+// FORMAT — no story-file coupling, which is what separates it from the
+// Problems-panel quick-fix that did retire.
+//
+// It is deliberately NOT the remedy for a story without an IFID: the toolchain
+// owns that now (minted at creation into `<story-name>.config.json`, rendered
+// into the header on save and build), so nothing here writes to a story.
+// Public interface: runIfidCommand(args).
+// Owner context: @sharpee/devkit (author tool).
 
 import { generateIfid, validateIfid, normalizeIfid } from '@sharpee/core';
 


### PR DESCRIPTION
David's ruling: *"sharpee ifid stays if anyone wants to use it."*

The command survived ADR-309's cleanup because it is a raw utility over the identifier **format**, with no story-file coupling — which is exactly what separated it from the Problems-panel quick-fix that did retire.

Its behavior needed no change (it generates and validates; it never told an author to hand-edit a header). What it lacked was a header saying so, and stating the part a future reader will wonder about: it is deliberately **not** the remedy for a story without an IFID, because the toolchain owns that now. Also corrects the file's stale path comment.

No behavior change. devkit **167 passing, 1 skipped**; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012myBrJ2H6X2YXEmoiHAWvi