### PR TITLE
fix(ci): build ESM target so vitest can resolve dist-esm/ packages

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -47,6 +47,16 @@ jobs:
     - name: Build platform packages + dungeo (repokit)
       run: ./repokit build dungeo --no-genai
 
+    # repokit builds the `local` target only (CJS -> dist/). 27 workspace packages
+    # also declare an ESM export condition pointing at dist-esm/, and vitest
+    # resolves through it — so any suite whose module graph reaches a workspace
+    # package via that condition dies on "Failed to resolve entry for package".
+    # Latent until @sharpee/character entered stdlib's graph (ADR-310/318, PR #270),
+    # which is when transcript-tester's barrel-importing suites started failing and
+    # main went red. ~30s.
+    - name: Build ESM target (dist-esm/) for the test runner
+      run: pnpm exec tsf build --target esm
+
     - name: Typecheck
       run: pnpm --filter '@sharpee/sharpee' exec tsc --noEmit
 


### PR DESCRIPTION
`Build Platforms` has been red on `main` since 2026-08-17 — runs `31994555186`
(PR #270 merge) and `31994615401` (PR #271 merge). Last green: 2026-08-15.

Two `@sharpee/transcript-tester` suites fail:

```
FAIL tests/aggregate.test.ts
FAIL tests/ok-any.test.ts
Error: Failed to resolve entry for package "@sharpee/character".
```

## Root cause

The workflow's only build step is `./repokit build dungeo --no-genai`, which
builds the tsf **`local`** target — CJS into `dist/`. But 27 workspace packages
also declare an ESM export condition:

```json
"exports": { ".": { "import": "./dist-esm/index.js", "require": "./dist/index.js" } }
```

vitest resolves through the `import` condition, so any suite whose module graph
reaches a workspace package that way cannot resolve — `dist-esm/` was never
built in CI.

Why only 2 of 23 suites: the two failures import the barrel `../src/index.js`,
which reaches `@sharpee/stdlib` → `src/npc/npc-service.ts` → `@sharpee/character`.
The 21 passing suites import narrow submodules (`../src/golden.js`,
`../src/types.js`) and never reach it.

Why now: the defect is structural and long-latent. It only became reachable when
ADR-310/318 (PR #270) put `@sharpee/character` into stdlib's graph — which is
exactly the merge where main went red.

Local dev never saw it because `dist-esm/` exists there from earlier ESM builds.
This is the dist-esm staleness trap in its most severe form: not stale, absent.

## Fix

One step, after the repokit build and before Typecheck/tests:

```yaml
- name: Build ESM target (dist-esm/) for the test runner
  run: pnpm exec tsf build --target esm
```

Deliberately **not** changing `@sharpee/character`'s exports — the ESM condition
is correct and shared by 27 packages. The defect is that CI builds one target
while the test runner resolves the other, so the build is what to fix.

## Evidence (2026-08-18, local)

- `npx tsf build --target esm` → `✓ Build complete`, **27.4s**; working tree
  clean afterward (`dist-esm/` is gitignored).
- `pnpm --filter '@sharpee/transcript-tester' test` → **23 test files passed,
  278 tests passed**, including `ok-any.test.ts` (3) and `aggregate.test.ts`
  (14) — the two red in CI.
- `pnpm exec turbo run test:ci` → EXIT 0.

The check on this PR is the real verification: it runs the amended workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
